### PR TITLE
Feature/add baseurl to env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ RESEND_API_KEY="YOUR_RESEND_API_KEY"
 
 ## production
 NODE_ENV="production"
-NEXT_PUBLIC_NODE_ENV="production"
+NEXT_PUBLIC_NODE_ENV="production" ## If using development `development`
 
 ## supabase for realtime broadcast
 NEXT_PUBLIC_SUPABASE_URL="YOUR_NEXT_PUBLIC_SUPABASE_URL"

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -12,7 +12,7 @@ export default {
       clientSecret: process.env.GOOGLE_CLIENT_SECRET! as string,
       authorization: {
         params: {
-          redirect_uri: `${isInProductionMode ? `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/callback/google` : 'http://localhost:3000/api/auth/callback/google'}`,
+          redirect_uri: `${isInProductionMode ? `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/callback/google` : `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/callback/google`}`,
         },
       },
       // profile: async (_profile) => {


### PR DESCRIPTION
# Pull Request Template

## Description
This Pull Request adds the configuration for `NEXT_PUBLIC_BASE_URL` in the `.env` file to dynamically switch between `development` and `production` environments. By updating the `NEXT_PUBLIC_NODE_ENV` variable in the `.env` file, the application can seamlessly toggle between local and production setups. 

---

## Related Issue
<!-- If this pull request fixes an issue, add "Fixes #<issue_number>" to automatically close the issue when merged. -->
N/A

---

## Changes Made
- Added `NEXT_PUBLIC_BASE_URL` to the `.env` file for managing environment-specific base URLs.

---

## How to Test
1. Open the `.env` file and update the `NODE_ENV` variable:
   - For **development**:
     ```env
     NEXT_PUBLIC_NODE_ENV="development"
     NEXT_PUBLIC_BASE_URL=http://localhost:3000
     ```
   - For **production**:
     ```env
     NEXT_PUBLIC_NODE_ENV="production"
     NEXT_PUBLIC_BASE_URL=https://your-production-url.com
     ```
2. Restart the development server after updating the `.env` file.
3. Verify that:
   - `NODE_ENV="development"` uses `http://localhost:3000` as the base URL.
   - `NODE_ENV="production"` uses `https://your-production-url.com` as the base URL.

4. Ensure API calls and redirects use the correct `baseURL` in both environments.

---

## Screenshots or Logs (if applicable)
N/A

---

## Checklist
- [x] I have tested my changes thoroughly.  
- [x] I have followed the project's code style guidelines.  
- [x] I have added/updated necessary documentation.  
- [x] I have linked relevant issues to this PR.  
- [x] I have ensured there are no new warnings or errors in the code.

---

## Notes for Reviewers
Make sure to set the correct `NEXT_PUBLIC_NODE_ENV` and `NEXT_PUBLIC_BASE_URL` values in the `.env` file before deploying the application. Let me know if further clarification is needed.
