### PR TITLE
fixing double render because of useEffect

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,33 +33,33 @@ const nextConfig = {
   //   optimisticClientCache: true,
   // },
 
-  async redirects() {
-    const isInMaintenanceMode = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === '1';
+  // async redirects() {
+  //   const isInMaintenanceMode = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === '1';
 
-    if (isInMaintenanceMode) {
-      return [
-        {
-          source: '/((?!maintenance).*)',
-          destination: '/maintenance',
-          permanent: false,
-        },
-        // {
-        //   source: '/(.*)',
-        //   has: [
-        //     {
-        //       type: 'header',
-        //       key: 'x-forwarded-proto',
-        //       value: 'http',
-        //     },
-        //   ],
-        //   destination: 'https://www.mondrey.dev/:path*',
-        //   permanent: true,
-        // },
-      ];
-    }
+  //   if (isInMaintenanceMode) {
+  //     return [
+  //       {
+  //         source: '/((?!maintenance).*)',
+  //         destination: '/maintenance',
+  //         permanent: false,
+  //       },
+  //       // {
+  //       //   source: '/(.*)',
+  //       //   has: [
+  //       //     {
+  //       //       type: 'header',
+  //       //       key: 'x-forwarded-proto',
+  //       //       value: 'http',
+  //       //     },
+  //       //   ],
+  //       //   destination: 'https://www.mondrey.dev/:path*',
+  //       //   permanent: true,
+  //       // },
+  //     ];
+  //   }
 
-    return [];
-  },
+  //   return [];
+  // },
   // pageExtensions: ['ts', 'tsx'],
   images: {
     remotePatterns: [

--- a/src/app/maintenance/page.tsx
+++ b/src/app/maintenance/page.tsx
@@ -9,21 +9,8 @@ interface MaintenancePageProps {
 }
 
 export default function MaintenancePage({ children }: MaintenancePageProps) {
-  const isMaintenanceMode = process.env.NEXT_PUBLIC_MAINTENANCE_MODE !== '1';
+  const isMaintenanceMode = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === '1';
   const router = useRouter();
-
-  useEffect(() => {
-    const originalWarn = console.warn;
-    console.warn = (...args) => {
-      if (typeof args[0] === 'string' && args[0].includes('was preloaded using link preload but not used')) {
-        return;
-      }
-      originalWarn(...args);
-    };
-    if (!isMaintenanceMode) {
-      router.push('/sign-in');
-    }
-  }, []);
 
   // Render maintenance page if in maintenance mode
   if (isMaintenanceMode) {


### PR DESCRIPTION
# Pull Request Template

## Description
Forgot to remove the redirect logic intended for the maintenance page. Additionally, removed the unnecessary `useEffect` which was causing the page to rerender twice. These changes aim to optimize the behavior of the application and resolve potential performance issues caused by the redundant logic.

---

## Related Issue
<!-- If this pull request fixes an issue, add "Fixes #<issue_number>" to automatically close the issue when merged. -->
Fixes #456  

---

## Changes Made
- Removed the maintenance page redirect logic that was unintentionally left in the code.
- Eliminated the `useEffect` hook to prevent double rerendering of the page.

Files updated:
- `app/maintenance/page.tsx` (removed redirect logic)
- `app/maintenance/page.tsx` (removed `useEffect` for unnecessary rerendering)

---

## How to Test
1. Run the application locally using `npm run dev`.
2. Verify that:
   - The redirect logic for the maintenance page no longer triggers incorrectly.
   - The page no longer rerenders unnecessarily.
3. Test navigation across all routes to confirm the application behaves as expected.
4. Check that the application functions correctly in both maintenance and non-maintenance modes.

---

## Screenshots or Logs (if applicable)
N/A – changes are primarily related to logic and performance optimization.

---

## Checklist
- [x] I have tested my changes thoroughly.  
- [x] I have followed the project's code style guidelines.  
- [x] I have added/updated necessary documentation.  
- [x] I have linked relevant issues to this PR.  
- [x] I have ensured there are no new warnings or errors in the code.

---

## Notes for Reviewers
Please review the updated logic to ensure no functionality was unintentionally removed. Additionally, confirm that the removal of `useEffect` does not impact other components relying on state or lifecycle behavior.
