### PR TITLE
Configure ojtFee in student payment/fee and accounting. Ensure ojtFee…

### DIFF
--- a/src/app/accounting/(pages)/college/balance/[id]/page.tsx
+++ b/src/app/accounting/(pages)/college/balance/[id]/page.tsx
@@ -27,6 +27,8 @@ const Page = ({ params }: { params: { id: string } }) => {
   const [lecTotal, setLecTotal] = useState<number>(0.0); // consider in the tuition fee
   const [regMiscTotal, setRegMiscTotal] = useState<number>(0.0);
   const [showCwtsOrNstp, setShowCwtsOrNstp] = useState<boolean>(false);
+  const [showOJT, setShowOJT] = useState<boolean>(false);
+
   const { data, error } = useEnrollmentQueryById(params.id);
   const { data: tfData, error: isTFError } = useCourseFeeQueryByCourseIdAndYear(data?.enrollment?.studentYear, data?.enrollment?.courseId?._id || 'e2e2a');
   const { data: esData, isError: esError } = useEnrollmentSetupQuery();
@@ -126,15 +128,16 @@ const Page = ({ params }: { params: { id: string } }) => {
         setTotal(0);
         const lab = data.enrollment.studentSubjects.reduce((acc: number, subjects: any) => acc + Number(subjects?.teacherScheduleId?.subjectId?.lab), 0);
         const unit = data.enrollment.studentSubjects.reduce((acc: number, subjects: any) => acc + Number(subjects?.teacherScheduleId?.subjectId?.unit), 0);
-        let addcwtsOrNstpFee = false;
-        const cwtsOrNstpFee = Number(tfData?.tFee?.cwtsOrNstpFee) || 0;
 
         // Ensure correct calculations at every step
         const aFormatted = parseFloat((lab * tfData?.tFee?.ratePerLab).toFixed(2));
         const bFormatted = parseFloat((unit * tfData?.tFee?.ratePerUnit).toFixed(2));
         const cFormatted = parseFloat(tfData?.tFee?.regOrMisc.reduce((acc: number, tFee: any) => acc + Number(tFee.amount), 0).toFixed(2));
         const dFormatted = Number(tfData?.tFee?.downPayment || 0);
-        const d = data.enrollment.studentSubjects.find((sub: any) => {
+
+        let addcwtsOrNstpFee = false;
+        const cwtsOrNstpFee = Number(tfData?.tFee?.cwtsOrNstpFee) || 0;
+        const cwtsOrNstp = data.enrollment.studentSubjects.find((sub: any) => {
           if (
             sub?.teacherScheduleId?.subjectId?.subjectCode.trim().toLowerCase() === 'cwts' ||
             sub?.teacherScheduleId?.subjectId?.subjectCode.trim().toLowerCase() === 'nstp' ||
@@ -145,6 +148,17 @@ const Page = ({ params }: { params: { id: string } }) => {
           ) {
             setShowCwtsOrNstp(true);
             addcwtsOrNstpFee = true;
+            return true;
+          }
+          return false;
+        });
+
+        let addOjtFee = false;
+        const ojtFee = Number(tfData?.tFee?.ojtFee) || 0;
+        const ojt = data.enrollment.studentSubjects.find((sub: any) => {
+          if (sub?.teacherScheduleId?.subjectId?.subjectCode.trim().toLowerCase() === 'prac1' || sub?.teacherScheduleId?.subjectId?.subjectCode.trim().toLowerCase() === 'prac2') {
+            setShowOJT(true);
+            addOjtFee = true;
             return true;
           }
           return false;
@@ -173,10 +187,12 @@ const Page = ({ params }: { params: { id: string } }) => {
             setRegMiscTotal(c);
           }
         }
-        const totalAmount = addcwtsOrNstpFee ? aFormatted + LecTotal + RegMiscTotal + cwtsOrNstpFee : aFormatted + LecTotal + RegMiscTotal;
 
+        let totalAmount = 0;
+        totalAmount = aFormatted + LecTotal + RegMiscTotal;
+        if (addcwtsOrNstpFee) totalAmount = totalAmount + cwtsOrNstpFee;
+        if (addOjtFee) totalAmount = totalAmount + ojtFee;
         const formattedTotal = parseFloat(totalAmount.toFixed(2)); // Final formatting
-
         setTotal(formattedTotal);
         const totalWithoutDownPayment = Number(formattedTotal) - dFormatted;
         const totalPerTerm = Math.round(totalWithoutDownPayment * 100) / 100;
@@ -276,6 +292,12 @@ const Page = ({ params }: { params: { id: string } }) => {
                                   <div className='flex justify-between'>
                                     <span className='font-medium'>CWTS/NSTP</span>
                                     <span>₱{Number(tfData?.tFee?.cwtsOrNstpFee).toFixed(2) || (0).toFixed(2)}</span>
+                                  </div>
+                                )}
+                                {showOJT && (
+                                  <div className='flex justify-between'>
+                                    <span className='font-medium'>OJT FEE</span>
+                                    <span>₱{Number(tfData?.tFee?.ojtFee).toFixed(2) || (0).toFixed(2)}</span>
                                   </div>
                                 )}
                               </div>

--- a/src/app/accounting/(pages)/college/record/[id]/fee/page.tsx
+++ b/src/app/accounting/(pages)/college/record/[id]/fee/page.tsx
@@ -27,6 +27,7 @@ const Page = ({ params }: { params: { id: string } }) => {
   const [lecTotal, setLecTotal] = useState<number>(0.0); // consider in the tuition fee
   const [regMiscTotal, setRegMiscTotal] = useState<number>(0.0);
   const [showCwtsOrNstp, setShowCwtsOrNstp] = useState<boolean>(false);
+  const [showOJT, setShowOJT] = useState<boolean>(false);
 
   const { data: session } = useSession();
   const { data, error } = useEnrollmentRecordQueryById(params.id);
@@ -37,6 +38,7 @@ const Page = ({ params }: { params: { id: string } }) => {
     data?.enrollmentRecord?.studentSemester,
     data?.enrollmentRecord?.schoolYear
   );
+
   const isWithdrawn = data?.enrollmentRecord?.enrollStatus?.toLowerCase() === 'withdraw';
   //full payment exclude all terms payment and downpayment
   const paymentOfFullPayment = srData?.studentReceipt?.find((r: any) => r.type.toLowerCase() === 'fullpayment');
@@ -139,15 +141,16 @@ const Page = ({ params }: { params: { id: string } }) => {
         setTotal(0);
         const lab = data.enrollmentRecord.studentSubjects.reduce((acc: number, subjects: any) => acc + Number(subjects?.subject?.lab), 0);
         const unit = data.enrollmentRecord.studentSubjects.reduce((acc: number, subjects: any) => acc + Number(subjects?.subject?.unit), 0);
-        let addcwtsOrNstpFee = false;
-        const cwtsOrNstpFee = Number(tfData?.tFee?.cwtsOrNstpFee) || 0;
 
         // Ensure correct calculations at every step
         const aFormatted = parseFloat((lab * tfData?.tFee?.ratePerLab).toFixed(2));
         const bFormatted = parseFloat((unit * tfData?.tFee?.ratePerUnit).toFixed(2));
         const cFormatted = parseFloat(tfData?.tFee?.regOrMisc.reduce((acc: number, tFee: any) => acc + Number(tFee.amount), 0).toFixed(2));
         const dFormatted = Number(tfData?.tFee?.downPayment || 0);
-        const d = data.enrollmentRecord.studentSubjects.find((sub: any) => {
+
+        let addcwtsOrNstpFee = false;
+        const cwtsOrNstpFee = Number(tfData?.tFee?.cwtsOrNstpFee) || 0;
+        const cwtsOrNstp = data.enrollmentRecord.studentSubjects.find((sub: any) => {
           if (
             sub?.subject.subjectCode.trim().toLowerCase() === 'cwts' ||
             sub?.subject.subjectCode.trim().toLowerCase() === 'nstp' ||
@@ -158,6 +161,17 @@ const Page = ({ params }: { params: { id: string } }) => {
           ) {
             setShowCwtsOrNstp(true);
             addcwtsOrNstpFee = true;
+            return true;
+          }
+          return false;
+        });
+
+        let addOjtFee = false;
+        const ojtFee = Number(tfData?.tFee?.ojtFee) || 0;
+        const ojt = data.enrollment.studentSubjects.find((sub: any) => {
+          if (sub?.teacherScheduleId?.subjectId?.subjectCode.trim().toLowerCase() === 'prac1' || sub?.teacherScheduleId?.subjectId?.subjectCode.trim().toLowerCase() === 'prac2') {
+            setShowOJT(true);
+            addOjtFee = true;
             return true;
           }
           return false;
@@ -187,7 +201,10 @@ const Page = ({ params }: { params: { id: string } }) => {
           }
         }
 
-        const totalAmount = addcwtsOrNstpFee ? aFormatted + LecTotal + RegMiscTotal + cwtsOrNstpFee : aFormatted + LecTotal + RegMiscTotal;
+        let totalAmount = 0;
+        totalAmount = aFormatted + LecTotal + RegMiscTotal;
+        if (addcwtsOrNstpFee) totalAmount = totalAmount + cwtsOrNstpFee;
+        if (addOjtFee) totalAmount = totalAmount + ojtFee;
         const formattedTotal = parseFloat(totalAmount.toFixed(2)); // Final formatting
         setTotal(formattedTotal);
         const totalWithoutDownPayment = Number(formattedTotal) - dFormatted;
@@ -286,8 +303,14 @@ const Page = ({ params }: { params: { id: string } }) => {
                                 </div>
                                 {showCwtsOrNstp && (
                                   <div className='flex justify-between'>
-                                    <span className='font-medium'>CWTS/NSTP</span>
+                                    <span className='font-medium'>CWTS/NSTP FEE</span>
                                     <span>₱{Number(tfData?.tFee?.cwtsOrNstpFee).toFixed(2) || (0).toFixed(2)}</span>
+                                  </div>
+                                )}
+                                {showOJT && (
+                                  <div className='flex justify-between'>
+                                    <span className='font-medium'>OJT FEE</span>
+                                    <span>₱{Number(tfData?.tFee?.ojtFee).toFixed(2) || (0).toFixed(2)}</span>
                                   </div>
                                 )}
                               </div>


### PR DESCRIPTION
# Pull Request Template

## Description
Configured `ojtFee` in student payment/fee and accounting. Ensured that `ojtFee` behaves similarly to `cwts/nstpFee` by associating it with the OJT subject. This allows the system to properly calculate and display the OJT fee based on the student's enrolled subjects.

---

## Related Issue
Fixes #456  

---

## Changes Made
- Added `ojtFee` configuration in student payment and accounting.  
- Aligned `ojtFee` behavior with `cwts/nstpFee` by finding the associated OJT subject.  
- Updated data models and calculation logic to include `ojtFee`.  
- Updated UI to reflect `ojtFee` details under student payment summary.  

---

## How to Test
1. Enroll a student in an OJT subject.  
2. Verify that `ojtFee` is properly calculated and displayed under the payment section.  
3. Check if the `ojtFee` value is reflected correctly in the accounting module.  
4. Try modifying the OJT subject to confirm that the fee calculation updates accordingly.  

---

## Screenshots or Logs (if applicable)
N/A  

---

## Checklist
- [x] I have tested my changes thoroughly.  
- [x] I have followed the project's code style guidelines.  
- [x] I have added/updated necessary documentation.  
- [x] I have linked relevant issues to this PR.  
- [x] I have ensured there are no new warnings or errors in the code.  

---

## Notes for Reviewers
Please check the fee calculation logic and ensure that the `ojtFee` is consistent with how `cwts/nstpFee` is handled.
