### PR TITLE
Allow payment to deduct from previous balance, fix downpayment record bug, hide full payment if balance exists

### DIFF
--- a/src/action/studentReceipt/create/helpers/cash.ts
+++ b/src/action/studentReceipt/create/helpers/cash.ts
@@ -41,49 +41,96 @@ const checkPaymentInDownPaymentExceed = async (user: any, student: any, data: an
     if (data.previousBalance && data.previousBalance.length > 0 && data?.type?.toLowerCase() !== 'downpayment' && data?.type?.toLowerCase() !== 'ssg' && data?.type?.toLowerCase() !== 'departmental' && data?.type?.toLowerCase() !== 'insurance') {
       // await checkBalance(studentEnrollment.studentYear, studentEnrollment.studentSemester, student._id.toString(), studentReceipt);
       let amountPaid = 0;
+      amountPaid = data.taxes.amount;
       if (data.perTermPaymentCurrent > 0) amountPaid = data.taxes.amount - data.perTermPaymentCurrent;
-      console.log('perTermPaymentCurrent', data.perTermPaymentCurrent);
-      console.log('amountPaid', amountPaid);
       for (const prev of data.previousBalance) {
         if (Number(amountPaid) > 0) {
           let type = '';
           let amount;
-          if (prev.finalBalance > 0) {
-            type = 'final';
-            amount = prev.finalBalance;
-          }
-          if (prev.semiFinalBalance > 0) {
-            type = 'semi-final';
-            amount = prev.semiFinalBalance;
-          }
-          if (prev.midtermBalance > 0) {
-            type = 'midterm';
-            amount = prev.midtermBalance;
-          }
-          if (prev.prelimBalance > 0) {
-            type = 'prelim';
-            amount = prev.prelimBalance;
-          }
           const captures = {
             id: '',
             amount: {
               currency_code: data?.amount?.currency_code,
               value: data?.amount?.value,
             },
-            taxes: {
-              fee: '',
-              fixed: '',
-              amount: amountPaid > amount ? Number(amount || 0) : Number(amountPaid || 0),
-            },
+
             isPaidIn: {
               year: studentEnrollment.studentYear,
               semester: studentEnrollment.studentSemester,
             },
-            type: type,
           };
-          const createdReceipt = await createStudentReceipt({ ...data2, ...captures, year: prev.year, semester: prev.semester });
-          if (!createdReceipt) return { error: 'Something went wrong.', status: 500 };
-          amountPaid = Number(amountPaid - amount);
+          if (Number(amountPaid) > 0) {
+            if (prev.prelimBalance > 0) {
+              type = 'prelim';
+              amount = prev.prelimBalance;
+              const createdReceipt = await createStudentReceipt({
+                ...data2,
+                ...captures,
+                taxes: { amount: amountPaid > amount ? Number(amount || 0) : Number(amountPaid || 0) },
+                year: prev.year,
+                semester: prev.semester,
+                schoolYear: prev.schoolYear,
+                type: type,
+              });
+              if (!createdReceipt) return { error: 'Something went wrong.', status: 500 };
+              amountPaid = Number(amountPaid - amount);
+            }
+          }
+          if (Number(amountPaid) > 0) {
+            if (prev.midtermBalance > 0) {
+              type = 'midterm';
+              amount = prev.midtermBalance;
+              const createdReceipt = await createStudentReceipt({
+                ...data2,
+                ...captures,
+                taxes: { amount: amountPaid > amount ? Number(amount || 0) : Number(amountPaid || 0) },
+                year: prev.year,
+                semester: prev.semester,
+                schoolYear: prev.schoolYear,
+                type: type,
+              });
+              if (!createdReceipt) return { error: 'Something went wrong.', status: 500 };
+              amountPaid = Number(amountPaid - amount);
+            }
+          }
+          console.log('amountPaid', amountPaid);
+          if (Number(amountPaid) > 0) {
+            if (prev.semiFinalBalance > 0) {
+              type = 'semi-final';
+              amount = prev.semiFinalBalance;
+              const createdReceipt = await createStudentReceipt({
+                ...data2,
+                ...captures,
+                taxes: { amount: amountPaid > amount ? Number(amount || 0) : Number(amountPaid || 0) },
+                year: prev.year,
+                semester: prev.semester,
+                schoolYear: prev.schoolYear,
+                type: type,
+              });
+              if (!createdReceipt) return { error: 'Something went wrong.', status: 500 };
+              amountPaid = Number(amountPaid - amount);
+            }
+            if (Number(amountPaid) > 0) {
+              if (prev.finalBalance > 0) {
+                type = 'final';
+                amount = prev.finalBalance;
+                const createdReceipt = await createStudentReceipt({
+                  ...data2,
+                  ...captures,
+                  taxes: { amount: amountPaid > amount ? Number(amount || 0) : Number(amountPaid || 0) },
+                  year: prev.year,
+                  semester: prev.semester,
+                  schoolYear: prev.schoolYear,
+                  type: type,
+                });
+                if (!createdReceipt) return { error: 'Something went wrong.', status: 500 };
+                amountPaid = Number(amountPaid - amount);
+              }
+            }
+          }
+
+          // const createdReceipt = await createStudentReceipt({ ...data2, ...captures, year: prev.year, semester: prev.semester, schoolYear: prev.schoolYear, type: type });
+          // if (!createdReceipt) return { error: 'Something went wrong.', status: 500 };
         }
       }
     }

--- a/src/app/(user)/(pages)/fee/components/SettleTermPayment.tsx
+++ b/src/app/(user)/(pages)/fee/components/SettleTermPayment.tsx
@@ -25,7 +25,7 @@ type IProps = {
 const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const paypalContainerRef = useRef(null);
-  const [amountInput, setAmountInput] = useState(1000.0);
+  const [insuranceFee, setInsuranceFee] = useState(false);
   const [amountPayment, setAmountPayment] = useState(0.0);
   const [extraPayment, setExtraPayment] = useState(0.0);
   const totalPaymentRef = useRef(0);
@@ -38,10 +38,12 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
     if (!tfData) return;
 
     if (tfData) {
+      const insurence = !srData.insurancePayment || srData?.insurancePaymentSemester?.toLowerCase() === enrollment?.studentSemester?.toLowerCase();
+      setInsuranceFee(insurence);
       let totalAmountToPay = amountToPay;
       if (type === 'fullPayment' && !isScholarshipStart) totalAmountToPay = parseFloat((amountToPay - amountToPay * 0.1).toFixed(2));
       setAmountPayment(totalAmountToPay);
-      const a = Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(tfData?.insuranceFee || 0);
+      const a = Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0);
       setExtraPayment(a);
       if (type.toLowerCase() === 'fullpayment') totalAmountToPay = totalAmountToPay + a;
 
@@ -211,14 +213,17 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-end w-full'>₱{tfData.departmentalFee}</span>
                             </div>
                           </div>
-                          <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
-                            <div className='text-sm mt-5 w-full flex items-start'>
-                              <span className='font-bold text-nowrap'>Insurance Fee:</span>
+                          {insuranceFee && (
+                            <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
+                              <div className='text-sm mt-5 w-full flex items-start'>
+                                <span className='font-bold text-nowrap'>Insurance Fee:</span>
+                              </div>
+
+                              <div className='text-sm mt-5 w-ful flex items-end'>
+                                <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
+                              </div>
                             </div>
-                            <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
-                            </div>
-                          </div>
+                          )}
                           <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
                             <div className='text-sm mt-5 w-full flex items-start'>
                               <span className='font-bold text-nowrap'>SSG Fee:</span>

--- a/src/app/(user)/(pages)/fee/page.tsx
+++ b/src/app/(user)/(pages)/fee/page.tsx
@@ -53,13 +53,10 @@ const Page = () => {
   let showPaymentOfFullPayment = false;
   const totalofPerTermFullPayment = Math.round(Number(total - total * 0.1) * 100) / 100;
   showPaymentOfFullPayment =
-    paymentOfFullPayment &&
-    Math.round(Number(paymentOfFullPayment?.taxes?.amount) * 100) / 100 >= Math.round(Number(totalofPerTermFullPayment + Number(tfData?.tFee?.ssgFee || 0) + Number(tfData?.tFee?.departmentalFee || 0) + Number(tfData?.tFee?.insuranceFee || 0)) * 100) / 100;
-
+    paymentOfFullPayment && Math.round(Number(paymentOfFullPayment?.taxes?.amount) * 100) / 100 >= Math.round(Number(totalofPerTermFullPayment + Number(tfData?.tFee?.ssgFee || 0) + Number(tfData?.tFee?.departmentalFee || 0)) * 100) / 100;
   const scholarship = isScholarshipApplicable(data?.enrollment?.studentYear, data?.enrollment?.studentSemester, data?.enrollment?.profileId?.scholarshipId);
   const isScholarshipStart = scholarship && data?.enrollment?.profileId?.scholarshipId;
   if (isScholarshipStart) showPaymentOfFullPayment = paymentOfFullPayment && Math.round(Number(paymentOfFullPayment?.taxes?.amount) * 100) / 100 === Math.round(Number(total) * 100) / 100;
-
   // Down Payment
   const paymentOfDownPayment = srData?.studentReceipt.find((r: any) => r.type.toLowerCase() === 'downpayment');
   const showPaymentOfDownPayment = paymentOfDownPayment && Number(paymentOfDownPayment?.taxes?.amount) >= Number(500);
@@ -146,7 +143,7 @@ const Page = () => {
       setShowBalance(0);
     }
   }, [total, paymentOfFullPayment, srData, showPaymentOfFullPayment, paymentOfDownPayment, paymentOfPrelim, paymentOfMidterm, paymentOfSemiFinal, paymentOfFinal, showBalance, data, isScholarshipStart]);
-
+console.log('srData', srData);
   useEffect(() => {
     if (isTFError || !tfData) return;
     if (error || !data) return;
@@ -459,26 +456,36 @@ const Page = () => {
                           !showPaymentOfSemiFinal &&
                           !showPaymentOfFinal && (
                             <div className='flex flex-col justify-center items-center w-full border-[0.5px] rounded-lg px-5 py-3'>
-                              <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
-                                <h1 className='flex gap-x-2 justify-center items-center'>
-                                  <span className='text-[16px] font-bold text-orange-400'>Note:</span>
-                                  <span className='text-sm text-justify'>
-                                    Full payment for the semester is only applicable for the initial payment and includes a 10% discount. {isScholarshipStart && 'For more details 10% discount is only available for students who does not have a schollarship.'}
-                                  </span>
-                                </h1>
-                              </div>
+                              {srData?.overAllBalance <= 0 && (
+                                <>
+                                  <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
+                                    <h1 className='flex gap-x-2 justify-center items-center'>
+                                      <span className='text-[16px] font-bold text-orange-400'>Note:</span>
+                                      <span className='text-sm text-justify'>
+                                        Full payment for the semester is only applicable for the initial payment and includes a 10% discount.{' '}
+                                        {isScholarshipStart && 'For more details 10% discount is only available for students who does not have a schollarship.'}
+                                      </span>
+                                    </h1>
+                                  </div>
+                                </>
+                              )}
                               <div className='flex items-center justify-center flex-col'>
-                                <SettleTermPayment
-                                  perTermPayment={paymentPerTermCurrent}
-                                  enrollment={data?.enrollment}
-                                  tfData={tfData?.tFee}
-                                  srData={srData}
-                                  amountToPay={Number(total).toFixed(2)}
-                                  type={'fullPayment'}
-                                  title='Full Payment'
-                                  isScholarshipStart={isScholarshipStart}
-                                />
-                                <span className=''>or</span>
+                                {srData?.overAllBalance <= 0 && (
+                                  <>
+                                    <SettleTermPayment
+                                      perTermPayment={paymentPerTermCurrent}
+                                      enrollment={data?.enrollment}
+                                      tfData={tfData?.tFee}
+                                      srData={srData}
+                                      amountToPay={Number(total).toFixed(2)}
+                                      type={'fullPayment'}
+                                      title='Full Payment'
+                                      isScholarshipStart={isScholarshipStart}
+                                    />
+                                    <span className=''>or</span>
+                                  </>
+                                )}
+
                                 <DownPayment
                                   enrollment={data?.enrollment}
                                   tfData={tfData?.tFee}
@@ -660,7 +667,7 @@ const Page = () => {
                                   <>
                                     <TableRow>
                                       <TableCell className={`px-4 py-2 text-green-400 line-through`}>Down Payment</TableCell>
-                                      <TableCell className={`px-4 py-2 text-green-400 line-through`}>₱{Number(1000).toFixed(2)}</TableCell>
+                                      <TableCell className={`px-4 py-2 text-green-400 line-through`}>₱{Number(tfData?.tFee?.downPayment).toFixed(2)}</TableCell>
                                       <TableCell className={`px-4 py-2 uppercase font-semibold text-green-400`}>Paid</TableCell>
                                       <TableCell className={`px-4 py-2 uppercase font-semibold text-green-400`}>Completed</TableCell>
                                     </TableRow>

--- a/src/app/(user)/(pages)/record/college/[id]/fee/components/DownPayment.tsx
+++ b/src/app/(user)/(pages)/record/college/[id]/fee/components/DownPayment.tsx
@@ -75,6 +75,7 @@ const DownPayment = ({ enrollment, tfData, srData, type, title, isScholarshipSta
           category: 'College',
           orderID: details.id,
           transactionId: details.id,
+          enrollmentId: enrollment?._id,
           amount: {
             currency_code: details.purchase_units[0].amount.currency_code,
             value: parseFloat(details.purchase_units[0].amount.value),
@@ -98,6 +99,7 @@ const DownPayment = ({ enrollment, tfData, srData, type, title, isScholarshipSta
           // payments: details.payment
           type: type,
           captureTime: new Date(details.update_time),
+          request: 'record',
         };
 
         mutation.mutate(receipt, {

--- a/src/app/(user)/(pages)/record/college/[id]/fee/components/SettleTermPayment.tsx
+++ b/src/app/(user)/(pages)/record/college/[id]/fee/components/SettleTermPayment.tsx
@@ -23,6 +23,7 @@ type IProps = {
 const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [amountPayment, setAmountPayment] = useState(0.0);
+  const [insuranceFee, setInsuranceFee] = useState(false);
   const [extraPayment, setExtraPayment] = useState(0.0);
   const totalPaymentRef = useRef(0);
   const totalTransactionFee = useRef(0);
@@ -34,10 +35,12 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
     if (!tfData) return;
 
     if (tfData) {
+      const insurence = !srData.insurancePayment || srData?.insurancePaymentSemester?.toLowerCase() === enrollment?.studentSemester?.toLowerCase();
+      setInsuranceFee(insurence);
       let totalAmountToPay = amountToPay;
       if (type === 'fullPayment' && !isScholarshipStart) totalAmountToPay = parseFloat((amountToPay - amountToPay * 0.1).toFixed(2));
       setAmountPayment(totalAmountToPay);
-      const a = Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(tfData?.insuranceFee || 0);
+      const a = Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0);
       setExtraPayment(a);
       if (type.toLowerCase() === 'fullpayment') totalAmountToPay = totalAmountToPay + a;
 
@@ -110,7 +113,6 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
           captureTime: new Date(details.update_time),
           request: 'record',
         };
-
         mutation.mutate(receipt, {
           onSuccess: (res: any) => {
             switch (res.status) {
@@ -211,14 +213,17 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-end w-full'>₱{tfData.departmentalFee}</span>
                             </div>
                           </div>
-                          <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
-                            <div className='text-sm mt-5 w-full flex items-start'>
-                              <span className='font-bold text-nowrap'>Insurance Fee:</span>
+                          {insuranceFee && (
+                            <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
+                              <div className='text-sm mt-5 w-full flex items-start'>
+                                <span className='font-bold text-nowrap'>Insurance Fee:</span>
+                              </div>
+
+                              <div className='text-sm mt-5 w-ful flex items-end'>
+                                <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
+                              </div>
                             </div>
-                            <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
-                            </div>
-                          </div>
+                          )}
                           <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
                             <div className='text-sm mt-5 w-full flex items-start'>
                               <span className='font-bold text-nowrap'>SSG Fee:</span>

--- a/src/app/accounting/(pages)/college/balance/[id]/components/SettleTermPayment.tsx
+++ b/src/app/accounting/(pages)/college/balance/[id]/components/SettleTermPayment.tsx
@@ -25,6 +25,7 @@ type IProps = {
 const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [total, setTotal] = useState(0.0);
+  const [insuranceFee, setInsuranceFee] = useState(false);
   const [amountPayment, setAmountPayment] = useState(0.0);
   const [amountInput, setAmountInput] = useState(0);
   const amountInputRef = useRef(0);
@@ -46,10 +47,12 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
     if (!tfData) return;
 
     if (tfData) {
+      const insurence = !srData.insurancePayment || srData?.insurancePaymentSemester?.toLowerCase() === enrollment?.studentSemester?.toLowerCase();
+      setInsuranceFee(insurence);
       let totalAmountToPay = amountToPay;
       if (!isScholarshipStart && type === 'fullPayment') totalAmountToPay = parseFloat((amountToPay - amountToPay * 0.1).toFixed(2));
       setAmountPayment(totalAmountToPay);
-      if (type.toLowerCase() === 'fullpayment') totalAmountToPay = totalAmountToPay + Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(tfData?.insuranceFee || 0);
+      if (type.toLowerCase() === 'fullpayment') totalAmountToPay = totalAmountToPay + Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0);
       setAmountInput(totalAmountToPay);
       setTotal(totalAmountToPay);
       if (enrollment?.profileId?.scholarshipId?.amount) {
@@ -179,14 +182,17 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-end w-full'>₱{tfData.departmentalFee}</span>
                             </div>
                           </div>
-                          <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
-                            <div className='text-sm mt-5 w-full flex items-start'>
-                              <span className='font-bold text-nowrap'>Insurance Fee:</span>
+                          {insuranceFee && (
+                            <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
+                              <div className='text-sm mt-5 w-full flex items-start'>
+                                <span className='font-bold text-nowrap'>Insurance Fee:</span>
+                              </div>
+
+                              <div className='text-sm mt-5 w-ful flex items-end'>
+                                <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
+                              </div>
                             </div>
-                            <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
-                            </div>
-                          </div>
+                          )}
                           <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
                             <div className='text-sm mt-5 w-full flex items-start'>
                               <span className='font-bold text-nowrap'>SSG Fee:</span>

--- a/src/app/accounting/(pages)/college/balance/[id]/page.tsx
+++ b/src/app/accounting/(pages)/college/balance/[id]/page.tsx
@@ -52,8 +52,7 @@ const Page = ({ params }: { params: { id: string } }) => {
   let showPaymentOfFullPayment = false;
   const totalofPerTermFullPayment = Math.round(Number(total - total * 0.1) * 100) / 100;
   showPaymentOfFullPayment =
-    paymentOfFullPayment &&
-    Math.round(Number(paymentOfFullPayment?.taxes?.amount) * 100) / 100 >= Math.round(Number(totalofPerTermFullPayment + Number(tfData?.tFee?.ssgFee || 0) + Number(tfData?.tFee?.departmentalFee || 0) + Number(tfData?.tFee?.insuranceFee || 0)) * 100) / 100;
+    paymentOfFullPayment && Math.round(Number(paymentOfFullPayment?.taxes?.amount) * 100) / 100 >= Math.round(Number(totalofPerTermFullPayment + Number(tfData?.tFee?.ssgFee || 0) + Number(tfData?.tFee?.departmentalFee || 0)) * 100) / 100;
 
   const scholarship = isScholarshipApplicable(data?.enrollment?.studentYear, data?.enrollment?.studentSemester, data?.enrollment?.profileId?.scholarshipId);
   const isScholarshipStart = scholarship && data?.enrollment?.profileId?.scholarshipId && data?.enrollment?.profileId?.scholarshipId;
@@ -454,47 +453,65 @@ const Page = ({ params }: { params: { id: string } }) => {
                           <>
                             {data?.enrollment?.profileId?.scholarshipId?.type.toLowerCase() !== 'fixed' ? (
                               <div className='flex flex-col justify-center items-center w-full border-[0.5px] rounded-lg px-5 py-3'>
-                                <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
-                                  <h1 className='flex gap-x-2 justify-center items-center'>
-                                    <span className='text-[16px] font-bold text-orange-400'>Note:</span>
-                                    <span className='text-sm text-justify'>Full payment for the semester is only applicable for the initial payment and includes a 10% discount.</span>
-                                  </h1>
-                                </div>
+                                {srData?.overAllBalance < 0 && (
+                                  <>
+                                    <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
+                                      <h1 className='flex gap-x-2 justify-center items-center'>
+                                        <span className='text-[16px] font-bold text-orange-400'>Note:</span>
+                                        <span className='text-sm text-justify'>Full payment for the semester is only applicable for the initial payment and includes a 10% discount.</span>
+                                      </h1>
+                                    </div>
+                                  </>
+                                )}
                                 <div className='flex flex-col items-center justify-center'>
-                                  <SettleTermPayment
-                                    perTermPayment={paymentPerTermCurrent}
-                                    enrollment={data?.enrollment}
-                                    tfData={tfData?.tFee}
-                                    srData={srData}
-                                    amountToPay={Number(total).toFixed(2)}
-                                    type={'fullPayment'}
-                                    title='Full Payment'
-                                    isScholarshipStart={isScholarshipStart}
-                                  />
-                                  <span className='text-sm uppercase font-semibold'>OR</span>
+                                  {srData?.overAllBalance < 0 && (
+                                    <>
+                                      <SettleTermPayment
+                                        perTermPayment={paymentPerTermCurrent}
+                                        enrollment={data?.enrollment}
+                                        tfData={tfData?.tFee}
+                                        srData={srData}
+                                        amountToPay={Number(total).toFixed(2)}
+                                        type={'fullPayment'}
+                                        title='Full Payment'
+                                        isScholarshipStart={isScholarshipStart}
+                                      />
+                                      <span className='text-sm uppercase font-semibold'>OR</span>
+                                    </>
+                                  )}
+
                                   <DownPayment enrollment={data?.enrollment} tfData={tfData?.tFee} srData={srData} amountToPay={Number(tfData?.tFee?.downPayment).toFixed(2)} type={'downPayment'} title='Down Payment' isScholarshipStart={isScholarshipStart} />
                                 </div>
                               </div>
                             ) : Number(data?.enrollment?.profileId?.scholarshipId.amount) >= Number(total) ? (
                               <div className='flex flex-col justify-center items-center w-full border-[0.5px] rounded-lg px-5 py-3'>
-                                <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
-                                  <h1 className='flex gap-x-2 justify-center items-center'>
-                                    <span className='text-[16px] font-bold text-orange-400'>Note:</span>
-                                    <span className='text-sm text-justify'>Full payment for the semester is only applicable for the initial payment and includes a 10% discount.</span>
-                                  </h1>
-                                </div>
+                                {srData?.overAllBalance < 0 && (
+                                  <>
+                                    <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
+                                      <h1 className='flex gap-x-2 justify-center items-center'>
+                                        <span className='text-[16px] font-bold text-orange-400'>Note:</span>
+                                        <span className='text-sm text-justify'>Full payment for the semester is only applicable for the initial payment and includes a 10% discount.</span>
+                                      </h1>
+                                    </div>
+                                  </>
+                                )}
+
                                 <div className='flex flex-col items-center justify-center'>
-                                  <SettleTermPayment
-                                    perTermPayment={paymentPerTermCurrent}
-                                    enrollment={data?.enrollment}
-                                    tfData={tfData?.tFee}
-                                    srData={srData}
-                                    amountToPay={Number(total).toFixed(2)}
-                                    type={'fullPayment'}
-                                    title='Full Payment'
-                                    isScholarshipStart={isScholarshipStart}
-                                  />
-                                  <span className='text-sm uppercase font-semibold'>OR</span>
+                                  {srData?.overAllBalance < 0 && (
+                                    <>
+                                      <SettleTermPayment
+                                        perTermPayment={paymentPerTermCurrent}
+                                        enrollment={data?.enrollment}
+                                        tfData={tfData?.tFee}
+                                        srData={srData}
+                                        amountToPay={Number(total).toFixed(2)}
+                                        type={'fullPayment'}
+                                        title='Full Payment'
+                                        isScholarshipStart={isScholarshipStart}
+                                      />
+                                      <span className='text-sm uppercase font-semibold'>OR</span>
+                                    </>
+                                  )}
                                   <DownPayment enrollment={data?.enrollment} tfData={tfData?.tFee} srData={srData} amountToPay={Number(tfData?.tFee?.downPayment).toFixed(2)} type={'downPayment'} title='Down Payment' isScholarshipStart={isScholarshipStart} />
                                 </div>
                               </div>
@@ -656,7 +673,7 @@ const Page = ({ params }: { params: { id: string } }) => {
                                   <>
                                     <TableRow>
                                       <TableCell className={`px-4 py-2 text-green-400 line-through`}>Down Payment</TableCell>
-                                      <TableCell className={`px-4 py-2 text-green-400 line-through`}>₱{Number(1000).toFixed(2)}</TableCell>
+                                      <TableCell className={`px-4 py-2 text-green-400 line-through`}>₱{Number(tfData?.tFee?.downPayment).toFixed(2)}</TableCell>
                                       <TableCell className={`px-4 py-2 uppercase font-semibold text-green-400`}>Paid</TableCell>
                                       <TableCell className={`px-4 py-2 uppercase font-semibold text-green-400`}>Completed</TableCell>
                                     </TableRow>

--- a/src/app/accounting/(pages)/college/record/[id]/fee/components/DownPayment.tsx
+++ b/src/app/accounting/(pages)/college/record/[id]/fee/components/DownPayment.tsx
@@ -66,6 +66,7 @@ const DownPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isS
     setIsPending(true);
     const receipt = {
       studentId: enrollment?.profileId?._id,
+      enrollmentId: enrollment?._id,
       category: 'College',
       amount: {
         currency_code: 'Php',
@@ -82,6 +83,7 @@ const DownPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isS
         amount: Number(amountInputRef.current).toFixed(2),
       },
       type: type,
+      request: 'record',
     };
 
     mutation.mutate(receipt, {

--- a/src/app/accounting/(pages)/college/record/[id]/fee/components/SettleTermPayment.tsx
+++ b/src/app/accounting/(pages)/college/record/[id]/fee/components/SettleTermPayment.tsx
@@ -25,6 +25,7 @@ type IProps = {
 const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [total, setTotal] = useState(0.0);
+  const [insuranceFee, setInsuranceFee] = useState(false);
   const [amountPayment, setAmountPayment] = useState(0.0);
   const [amountInput, setAmountInput] = useState(0);
   const amountInputRef = useRef(0);
@@ -46,10 +47,12 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
     if (!tfData) return;
 
     if (tfData) {
+      const insurence = !srData.insurancePayment || srData?.insurancePaymentSemester?.toLowerCase() === enrollment?.studentSemester?.toLowerCase();
+      setInsuranceFee(insurence);
       let totalAmountToPay = amountToPay;
       if (!isScholarshipStart && type === 'fullPayment') totalAmountToPay = parseFloat((amountToPay - amountToPay * 0.1).toFixed(2));
       setAmountPayment(totalAmountToPay);
-      if (type.toLowerCase() === 'fullpayment') totalAmountToPay = totalAmountToPay + Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(tfData?.insuranceFee || 0);
+      if (type.toLowerCase() === 'fullpayment') totalAmountToPay = totalAmountToPay + Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0);
       setAmountInput(totalAmountToPay);
       setTotal(totalAmountToPay);
       if (enrollment?.profileId?.scholarshipId?.amount) {
@@ -184,14 +187,17 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-end w-full'>₱{tfData.departmentalFee}</span>
                             </div>
                           </div>
-                          <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
-                            <div className='text-sm mt-5 w-full flex items-start'>
-                              <span className='font-bold text-nowrap'>Insurance Fee:</span>
+                          {insuranceFee && (
+                            <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
+                              <div className='text-sm mt-5 w-full flex items-start'>
+                                <span className='font-bold text-nowrap'>Insurance Fee:</span>
+                              </div>
+
+                              <div className='text-sm mt-5 w-ful flex items-end'>
+                                <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
+                              </div>
                             </div>
-                            <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
-                            </div>
-                          </div>
+                          )}
                           <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
                             <div className='text-sm mt-5 w-full flex items-start'>
                               <span className='font-bold text-nowrap'>SSG Fee:</span>

--- a/src/app/accounting/(pages)/college/record/[id]/fee/page.tsx
+++ b/src/app/accounting/(pages)/college/record/[id]/fee/page.tsx
@@ -56,8 +56,7 @@ const Page = ({ params }: { params: { id: string } }) => {
   let showPaymentOfFullPayment = false;
   const totalofPerTermFullPayment = Math.round(Number(total - total * 0.1) * 100) / 100;
   showPaymentOfFullPayment =
-    paymentOfFullPayment &&
-    Math.round(Number(paymentOfFullPayment?.taxes?.amount) * 100) / 100 >= Math.round(Number(totalofPerTermFullPayment + Number(tfData?.tFee?.ssgFee || 0) + Number(tfData?.tFee?.departmentalFee || 0) + Number(tfData?.tFee?.insuranceFee || 0)) * 100) / 100;
+    paymentOfFullPayment && Math.round(Number(paymentOfFullPayment?.taxes?.amount) * 100) / 100 >= Math.round(Number(totalofPerTermFullPayment + Number(tfData?.tFee?.ssgFee || 0) + Number(tfData?.tFee?.departmentalFee || 0)) * 100) / 100;
 
   const scholarship = isScholarshipApplicable(data?.enrollmentRecord?.studentYear, data?.enrollmentRecord?.studentSemester, data?.enrollmentRecord?.profileId?.scholarshipId);
   const isScholarshipStart = scholarship && data?.enrollmentRecord?.profileId?.scholarshipId && data?.enrollmentRecord?.profileId?.scholarshipId;
@@ -65,7 +64,7 @@ const Page = ({ params }: { params: { id: string } }) => {
 
   // Down Payment
   const paymentOfDownPayment = srData?.studentReceipt?.find((r: any) => r.type.toLowerCase() === 'downpayment');
-  const showPaymentOfDownPayment = paymentOfDownPayment && Number(paymentOfDownPayment?.taxes?.amount).toFixed(2) === Number(tfData?.tFee?.downPayment).toFixed(2);
+  const showPaymentOfDownPayment = paymentOfDownPayment && Number(paymentOfDownPayment?.taxes?.amount) >= Number(500);
 
   // Prelim Payment
   const paymentOfPrelim = srData?.studentReceipt
@@ -457,24 +456,33 @@ const Page = ({ params }: { params: { id: string } }) => {
                           <>
                             {data?.enrollmentRecord?.profileId?.scholarshipId?.type.toLowerCase() !== 'fixed' ? (
                               <div className='flex flex-col justify-center items-center w-full border-[0.5px] rounded-lg px-5 py-3'>
-                                <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
-                                  <h1 className='flex gap-x-2 justify-center items-center'>
-                                    <span className='text-[16px] font-bold text-orange-400'>Note:</span>
-                                    <span className='text-sm text-justify'>Full payment for the semester is only applicable for the initial payment and includes a 10% discount.</span>
-                                  </h1>
-                                </div>
+                                {srData?.overAllBalance <= 0 && (
+                                  <>
+                                    <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
+                                      <h1 className='flex gap-x-2 justify-center items-center'>
+                                        <span className='text-[16px] font-bold text-orange-400'>Note:</span>
+                                        <span className='text-sm text-justify'>Full payment for the semester is only applicable for the initial payment and includes a 10% discount.</span>
+                                      </h1>
+                                    </div>
+                                  </>
+                                )}
+
                                 <div className='flex flex-col items-center justify-center'>
-                                  <SettleTermPayment
-                                    perTermPayment={paymentPerTermCurrent}
-                                    enrollment={data?.enrollmentRecord}
-                                    tfData={tfData?.tFee}
-                                    srData={srData}
-                                    amountToPay={Number(total).toFixed(2)}
-                                    type={'fullPayment'}
-                                    title='Full Payment'
-                                    isScholarshipStart={isScholarshipStart}
-                                  />
-                                  <span className='text-sm uppercase font-semibold'>OR</span>
+                                  {srData?.overAllBalance <= 0 && (
+                                    <>
+                                      <SettleTermPayment
+                                        perTermPayment={paymentPerTermCurrent}
+                                        enrollment={data?.enrollmentRecord}
+                                        tfData={tfData?.tFee}
+                                        srData={srData}
+                                        amountToPay={Number(total).toFixed(2)}
+                                        type={'fullPayment'}
+                                        title='Full Payment'
+                                        isScholarshipStart={isScholarshipStart}
+                                      />
+                                      <span className='text-sm uppercase font-semibold'>OR</span>
+                                    </>
+                                  )}
                                   <DownPayment
                                     enrollment={data?.enrollment}
                                     tfData={tfData?.tFee}
@@ -488,24 +496,33 @@ const Page = ({ params }: { params: { id: string } }) => {
                               </div>
                             ) : Number(data?.enrollmentRecord?.profileId?.scholarshipId.amount) >= Number(total) ? (
                               <div className='flex flex-col justify-center items-center w-full border-[0.5px] rounded-lg px-5 py-3'>
-                                <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
-                                  <h1 className='flex gap-x-2 justify-center items-center'>
-                                    <span className='text-[16px] font-bold text-orange-400'>Note:</span>
-                                    <span className='text-sm text-justify'>Full payment for the semester is only applicable for the initial payment and includes a 10% discount.</span>
-                                  </h1>
-                                </div>
+                                {srData?.overAllBalance <= 0 && (
+                                  <>
+                                    <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
+                                      <h1 className='flex gap-x-2 justify-center items-center'>
+                                        <span className='text-[16px] font-bold text-orange-400'>Note:</span>
+                                        <span className='text-sm text-justify'>Full payment for the semester is only applicable for the initial payment and includes a 10% discount.</span>
+                                      </h1>
+                                    </div>
+                                  </>
+                                )}
+
                                 <div className='flex flex-col items-center justify-center'>
-                                  <SettleTermPayment
-                                    perTermPayment={paymentPerTermCurrent}
-                                    enrollment={data?.enrollmentRecord}
-                                    tfData={tfData?.tFee}
-                                    srData={srData}
-                                    amountToPay={Number(total).toFixed(2)}
-                                    type={'fullPayment'}
-                                    title='Full Payment'
-                                    isScholarshipStart={isScholarshipStart}
-                                  />
-                                  <span className='text-sm uppercase font-semibold'>OR</span>
+                                  {srData?.overAllBalance <= 0 && (
+                                    <>
+                                      <SettleTermPayment
+                                        perTermPayment={paymentPerTermCurrent}
+                                        enrollment={data?.enrollmentRecord}
+                                        tfData={tfData?.tFee}
+                                        srData={srData}
+                                        amountToPay={Number(total).toFixed(2)}
+                                        type={'fullPayment'}
+                                        title='Full Payment'
+                                        isScholarshipStart={isScholarshipStart}
+                                      />
+                                      <span className='text-sm uppercase font-semibold'>OR</span>
+                                    </>
+                                  )}
                                   <DownPayment enrollment={data?.enrollment} tfData={tfData?.tFee} srData={srData} amountToPay={Number(tfData?.tFee?.downPayment).toFixed(2)} type={'downPayment'} title='Down Payment' isScholarshipStart={isScholarshipStart} />
                                 </div>
                               </div>
@@ -561,7 +578,7 @@ const Page = ({ params }: { params: { id: string } }) => {
                                   <>
                                     <TableRow>
                                       <TableCell className={`px-4 py-2 ${(showPaymentOfFullPayment || showPaymentOfDownPayment) && 'text-green-400 line-through'}`}>Down Payment</TableCell>
-                                      <TableCell className={`px-4 py-2 ${(showPaymentOfFullPayment || showPaymentOfDownPayment) && 'text-green-400 line-through'}`}>₱{Number(tfData?.tFee?.downPayment).toFixed(2)}</TableCell>
+                                      <TableCell className={`px-4 py-2 ${(showPaymentOfFullPayment || showPaymentOfDownPayment) && 'text-green-400 line-through'}`}>₱{Number(paymentOfDownPayment?.taxes?.amount).toFixed(2)}</TableCell>
                                       <TableCell className={`px-4 py-2 uppercase font-semibold ${showPaymentOfFullPayment || showPaymentOfDownPayment ? 'text-green-400' : 'text-red'}`}>
                                         {showPaymentOfFullPayment || showPaymentOfDownPayment ? 'Paid' : 'unpaid'}
                                       </TableCell>
@@ -684,7 +701,7 @@ const Page = ({ params }: { params: { id: string } }) => {
                                   <>
                                     <TableRow>
                                       <TableCell className={`px-4 py-2 text-green-400 line-through`}>Down Payment</TableCell>
-                                      <TableCell className={`px-4 py-2 text-green-400 line-through`}>₱{Number(1000).toFixed(2)}</TableCell>
+                                      <TableCell className={`px-4 py-2 text-green-400 line-through`}>₱{Number(tfData?.tFee?.downPayment).toFixed(2)}</TableCell>
                                       <TableCell className={`px-4 py-2 uppercase font-semibold text-green-400`}>Paid</TableCell>
                                       <TableCell className={`px-4 py-2 uppercase font-semibold text-green-400`}>Completed</TableCell>
                                     </TableRow>


### PR DESCRIPTION
# Pull Request Template

## Description
- Allow payment to deduct from previous balance if the amount exceeds the current payment.  
- Fixed a bug where downpayment records were missing `request: 'record'` in the payment mutation data.  
- Hide full payment option if the student still has a balance from previous enrollment.  

---

## Related Issue
Fixes #456  

---

## Changes Made
- Updated payment logic to deduct excess amounts from previous balances.  
- Corrected the downpayment mutation request to include `record`.  
- Modified UI logic to hide the full payment option when a previous balance exists.  

---

## How to Test
1. Attempt a payment that exceeds the current semester's balance and verify it deducts from the previous balance.  
2. Process a downpayment and confirm that the record is correctly stored in the database.  
3. Check if the full payment option is hidden when there is an outstanding balance from a prior enrollment.  

---

## Screenshots or Logs (if applicable)
<!-- Attach screenshots or logs to highlight the changes made, especially for UI/UX-related PRs or major changes. -->

---

## Checklist
- [x] I have tested my changes thoroughly.  
- [x] I have followed the project's code style guidelines.  
- [x] I have added/updated necessary documentation.  
- [x] I have linked relevant issues to this PR.  
- [x] I have ensured there are no new warnings or errors in the code.  

---

## Notes for Reviewers
