### PR TITLE
Update profile edit and authorization, improve grade submission rules

### DIFF
--- a/src/action/profile/update/id/index.ts
+++ b/src/action/profile/update/id/index.ts
@@ -23,7 +23,7 @@ export const updateProfileByAdminAction = async (data: any) => {
     await dbConnect();
     const session = await checkAuth();
     if (!session || session.error) return { error: 'Not authenticated.', status: 403 };
-    if (session && session.user.role !== 'ADMIN') return { error: 'Dont have permission.', status: 403 };
+    if (session && session.user.role !== 'SUPER ADMIN' && session.user.role !== 'ADMIN') return { error: 'Dont have permission.', status: 403 };
 
     const checkedR = await checkSessionRole(data);
 

--- a/src/action/profile/update/session/index.ts
+++ b/src/action/profile/update/session/index.ts
@@ -10,6 +10,7 @@ import { checkAuth } from '@/utils/actions/session';
 import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
 import { storage } from '@/firebase';
 import { updateAccountingProfileByUserId } from '@/services/accountingProfile';
+import { updateSuperAdminProfileByUserId } from '@/services/superAdminProfile';
 
 /**
  * Update profile by session action
@@ -58,6 +59,9 @@ const checkSessionRole = async (session: any, data: any): Promise<any> => {
         break;
       case 'ADMIN':
         profile = await updateAdminProfile(session.user._id, data);
+        break;
+      case 'SUPER ADMIN':
+        profile = await updateSuperAdminProfile(session.user._id, data);
         break;
       case 'ACCOUNTING':
         profile = await updateAccountingProfile(session.user._id, data);
@@ -119,6 +123,26 @@ const updateDeanProfile = async (userId: string, data: any) => {
     }
     const profile = await updateDeanProfileByUserId(userId, data);
     if (!profile) return { error: 'Something went wrong. ', status: 500 };
+    return { message: 'Profile has been update. ', status: 201 };
+  });
+};
+
+/**
+ * update admin profile
+ *
+ * @param {String} userId
+ * @param {Object} data
+ */
+const updateSuperAdminProfile = async (userId: string, data: any) => {
+  return tryCatch(async () => {
+    if (!data.formData) {
+      const profileParse = AdminProfileUpdateValidator.safeParse(data);
+      if (!profileParse.success) return { error: 'Invalid fields!', status: 400 };
+    }
+
+    const profile = await updateSuperAdminProfileByUserId(userId, data);
+    if (!profile) return { error: 'Something went wrong. ', status: 500 };
+
     return { message: 'Profile has been update. ', status: 201 };
   });
 };

--- a/src/action/user/create/index.ts
+++ b/src/action/user/create/index.ts
@@ -25,7 +25,7 @@ export const adminCreateUserWithRoleAction = async (data: any) => {
     await dbConnect();
     const session = await checkAuth();
     if (!session || session.error) return { error: 'Not Authorized.', status: 403 };
-    if (session.user.role !== 'SUPER ADMIN') return { error: 'Not Authorized.', status: 403 };
+    if (session.user.role !== 'SUPER ADMIN' && session.user.role !== 'ADMIN') return { error: 'Not Authorized.', status: 403 };
 
     const checkConflict = await checkingConflict(data);
     if (checkConflict && checkConflict.error) return { error: checkConflict?.error, status: checkConflict?.status };

--- a/src/app/(user)/(pages)/enrollment/college/components/Step0.tsx
+++ b/src/app/(user)/(pages)/enrollment/college/components/Step0.tsx
@@ -263,8 +263,11 @@ const Step0 = ({ search, enrollmentSetup, courses }: IProps) => {
     }
     setFileGoodMoralError('');
     setTORError('');
-
     const profileData = form.getValues();
+    if (profileData.seniorHighSchoolName?.toLowerCase() === 'n/a') {
+      profileData.seniorHighSchoolYear = '';
+      profileData.seniorHighSchoolStrand = '';
+    }
     profileData.studentYear = profileData.studentYear.toLowerCase();
     const dataa = {
       ...profileData,

--- a/src/app/dean/(pages)/schedules/classes/[id]/components/Dialogs/CreateDialog.tsx
+++ b/src/app/dean/(pages)/schedules/classes/[id]/components/Dialogs/CreateDialog.tsx
@@ -117,7 +117,7 @@ const CreateDialog = ({ teacher, data, type }: IProps) => {
             <div className=''>
               <div className='text-orange-500'>Reminder:</div>
               <div className=''>
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Empty grades consider as <span className='text-red'>INC</span>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Empty grades cannot be submitted. If a grade is incomplete, input <span className='text-red'>INC</span>.
               </div>
             </div>
           </DialogDescription>

--- a/src/app/dean/(pages)/schedules/classes/[id]/components/Dialogs/CreateIndividualDialog.tsx
+++ b/src/app/dean/(pages)/schedules/classes/[id]/components/Dialogs/CreateIndividualDialog.tsx
@@ -118,7 +118,7 @@ const CreateIndividualDialog = ({ teacher, data }: IProps) => {
             <div className=''>
               <div className='text-orange-500'>Reminder:</div>
               <div className=''>
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Empty grades consider as <span className='text-red'>INC</span>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Empty grades cannot be submitted. If a grade is incomplete, input <span className='text-red'>INC</span>.
               </div>
             </div>
           </DialogDescription>

--- a/src/app/instructor/(pages)/schedules/classes/[id]/components/Dialogs/CreateDialog.tsx
+++ b/src/app/instructor/(pages)/schedules/classes/[id]/components/Dialogs/CreateDialog.tsx
@@ -117,7 +117,7 @@ const CreateDialog = ({ teacher, data, type }: IProps) => {
             <div className=''>
               <div className='text-orange-500'>Reminder:</div>
               <div className=''>
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Empty grades consider as <span className='text-red'>INC</span>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Empty grades cannot be submitted. If a grade is incomplete, input <span className='text-red'>INC</span>.
               </div>
             </div>
           </DialogDescription>

--- a/src/app/instructor/(pages)/schedules/classes/[id]/components/Dialogs/CreateIndividualDialog.tsx
+++ b/src/app/instructor/(pages)/schedules/classes/[id]/components/Dialogs/CreateIndividualDialog.tsx
@@ -118,7 +118,7 @@ const CreateIndividualDialog = ({ teacher, data }: IProps) => {
             <div className=''>
               <div className='text-orange-500'>Reminder:</div>
               <div className=''>
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Empty grades consider as <span className='text-red'>INC</span>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Empty grades cannot be submitted. If a grade is incomplete, input <span className='text-red'>INC</span>.
               </div>
             </div>
           </DialogDescription>

--- a/src/lib/validators/profile/extension/index.ts
+++ b/src/lib/validators/profile/extension/index.ts
@@ -4,9 +4,9 @@ export const StudentProfileExtension = z
   .object({
     studentStatus: z.string().min(1, { message: 'Student Status is required...' }),
     studentYear: z.string().min(1, { message: 'Student Year is required...' }),
-    primarySchoolName: z.string().min(5, { message: 'School Name is required...' }).max(40, { message: 'School Name length too long.' }),
+    primarySchoolName: z.string().min(5, { message: 'School Name is required...' }).max(100, { message: 'School Name length too long.' }),
     primarySchoolYear: z.string().min(4, { message: 'School Year is required...' }).max(20, { message: 'School Year length too long.' }),
-    secondarySchoolName: z.string().min(5, { message: 'School Name is required...' }).max(40, { message: 'School Name length too long.' }),
+    secondarySchoolName: z.string().min(5, { message: 'School Name is required...' }).max(100, { message: 'School Name length too long.' }),
     secondarySchoolYear: z.string().min(4, { message: 'School Year is required...' }).max(20, { message: 'School Year length too long.' }),
     seniorHighSchoolName: z.string().optional(),
     seniorHighSchoolYear: z.string().optional(),
@@ -23,7 +23,7 @@ export const StudentProfileExtension = z
     MothersEmail: z.string().optional(),
   })
   .superRefine((value, ctx) => {
-    if (value.seniorHighSchoolName !== 'n/a') {
+    if (value.seniorHighSchoolName === '' && value.seniorHighSchoolName.toLowerCase() !== 'n/a') {
       ctx.addIssue({
         code: 'custom',
         message: 'Senior High School is required or can be n/a.',


### PR DESCRIPTION
# Pull Request Template

## Description
- Restricted profile editing to super admins and admins only.
- Added admin and super admin authorization for user creation and editing.
- Updated enrollment mutation logic: If `seniorHighSchoolName` is 'N/A', `seniorHighSchoolYear` and `seniorHighSchoolStrand` will be cleared.
- Improved grade submission description: "Empty grades cannot be submitted. If a grade is incomplete, input INC" to ensure instructors review before assigning INC.

---

## Related Issue
Fixes #456  

---

## Changes Made
- Modified profile editing permissions to require super admin and admin authorization.
- Implemented authorization checks for user creation and editing.
- Adjusted enrollment validation logic for `seniorHighSchoolName` handling.
- Refined grade submission instructions to prevent auto-filling incomplete grades.

---

## How to Test
1. Log in as a super admin or admin and attempt to edit a profile—should be allowed.
2. Log in as an admin and try creating/editing a user—should work as expected.
3. Attempt to enroll a student with `seniorHighSchoolName` set to "N/A"—ensure `seniorHighSchoolYear` and `seniorHighSchoolStrand` are cleared.
4. Try submitting empty grades—should not allow submission unless marked as `INC`.

---

## Screenshots or Logs (if applicable)
<!-- Attach screenshots or logs to highlight the changes made, especially for UI/UX-related PRs or major changes. -->

---

## Checklist
- [x] I have tested my changes thoroughly.  
- [x] I have followed the project's code style guidelines.  
- [x] I have added/updated necessary documentation.  
- [x] I have linked relevant issues to this PR.  
- [x] I have ensured there are no new warnings or errors in the code.

---

## Notes for Reviewers
