### PR TITLE
Restrict payment when there is an ongoing enrollment (step >= 5) and display pending payment status. Ensure students cannot pay past enrollment if a current enrollment exists.

### DIFF
--- a/src/action/enrollment/get/session/index.ts
+++ b/src/action/enrollment/get/session/index.ts
@@ -15,10 +15,10 @@ export const getEnrollmentBySessionIdAction = async (id: string) => {
     await dbConnect();
     const session = await checkAuth();
     // Not authenticated || Not Foribidden
-    if (!session || session.error || session.user.role !== 'STUDENT' || id !== session.user._id) return { error: 'Foribidden.', status: 403 };
-
-    const enrollment = await getEnrollmentByUserId(session.user._id);
-
+    // if (!session || session.error || session.user.role !== 'STUDENT' || id !== session.user._id) return { error: 'Foribidden.', status: 403 };
+    let enrollment;
+    enrollment = await getEnrollmentByUserId(session.user._id);
+    if (session.user.role === 'ACCOUNTING') enrollment = await getEnrollmentByUserId(id);
     return { enrollment: JSON.parse(JSON.stringify(enrollment)), status: 200 };
   });
 };

--- a/src/services/enrollmentRecord.ts
+++ b/src/services/enrollmentRecord.ts
@@ -35,7 +35,7 @@ export const getEnrollmentRecordById = async (id: any) => {
     const TProfile = await EnrollmentRecord.findById(id)
       .populate({
         path: 'profileId',
-        populate: [{ path: 'scholarshipId' }],
+        populate: [{ path: 'scholarshipId' }, { path: 'userId' }],
       })
       .exec();
     return TProfile;


### PR DESCRIPTION
# Pull Request Template

## Description
Restricts students from making payments if they have an ongoing enrollment (`step >= 5`). Displays a pending payment status when applicable. Ensures students cannot pay past enrollment records if they already have a current enrollment.

---

## Related Issue
Fixes #456  

---

## Changes Made
- Prevent payment processing when a student has an active enrollment (`step >= 5`).
- Display a pending payment notice for the enrollment in progress.
- Ensure that previous enrollment records cannot be paid separately if a new enrollment exists.

---

## How to Test
1. Enroll a student and advance the enrollment step to `5` or higher.
2. Attempt to process a payment for the previous enrollment record.
3. Verify that the system blocks the payment and displays the correct pending status.

---

## Screenshots or Logs (if applicable)
N/A

---

## Checklist
- [x] I have tested my changes thoroughly.  
- [x] I have followed the project's code style guidelines.  
- [x] I have added/updated necessary documentation.  
- [x] I have linked relevant issues to this PR.  
- [x] I have ensured there are no new warnings or errors in the code.

---

## Notes for Reviewers
Please verify that the restriction logic aligns with the enrollment process flow.
