### PR TITLE
Include passbook fee in full payment calculation and fix full payment display when no previous balance exists

### DIFF
--- a/src/app/(user)/(pages)/fee/components/SettleTermPayment.tsx
+++ b/src/app/(user)/(pages)/fee/components/SettleTermPayment.tsx
@@ -20,9 +20,10 @@ type IProps = {
   title: string;
   isScholarshipStart: Boolean;
   perTermPayment: any;
+  passbookPaymentBoolean?: boolean;
 };
 
-const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment }: IProps) => {
+const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment, passbookPaymentBoolean }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const paypalContainerRef = useRef(null);
   const [insuranceFee, setInsuranceFee] = useState(false);
@@ -43,7 +44,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
       let totalAmountToPay = amountToPay;
       if (type === 'fullPayment' && !isScholarshipStart) totalAmountToPay = parseFloat((amountToPay - amountToPay * 0.1).toFixed(2));
       setAmountPayment(totalAmountToPay);
-      const a = Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0);
+      const a = Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0) + Number(passbookPaymentBoolean ? tfData?.passbookFee || 0 : 0);
       setExtraPayment(a);
       if (type.toLowerCase() === 'fullpayment') totalAmountToPay = totalAmountToPay + a;
 
@@ -52,7 +53,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
       const totalPayment = Number(totalAmountToPay) + Number(fee) + 15;
       totalPaymentRef.current = parseFloat(totalPayment.toFixed(2));
     }
-  }, [srData, tfData, enrollment, amountToPay, type, isScholarshipStart]);
+  }, [srData, tfData, enrollment, amountToPay, type, isScholarshipStart, passbookPaymentBoolean]);
 
   const formattedAmount = (amount: number) => {
     return amount ? amount.toFixed(2) : '0.00';
@@ -208,7 +209,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-nowrap'>Departmental Fee:</span>
                             </div>
                             <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.departmentalFee}</span>
+                              <span className='font-bold text-end w-full'>₱{tfData?.departmentalFee}</span>
                             </div>
                           </div>
                           {insuranceFee && (
@@ -218,7 +219,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               </div>
 
                               <div className='text-sm mt-5 w-ful flex items-end'>
-                                <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
+                                <span className='font-bold text-end w-full'>₱{tfData?.insuranceFee}</span>
                               </div>
                             </div>
                           )}
@@ -227,12 +228,22 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-nowrap'>SSG Fee:</span>
                             </div>
                             <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.ssgFee}</span>
+                              <span className='font-bold text-end w-full'>₱{tfData?.ssgFee}</span>
                             </div>
                           </div>
+                          {passbookPaymentBoolean && (
+                            <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
+                              <div className='text-sm mt-5 w-full flex items-start'>
+                                <span className='font-bold text-nowrap'>Passbook Fee:</span>
+                              </div>
+
+                              <div className='text-sm mt-5 w-ful flex items-end'>
+                                <span className='font-bold text-end w-full'>₱{tfData?.passbookFee}</span>
+                              </div>
+                            </div>
+                          )}
                         </>
                       )}
-
                       <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
                         <div className='text-sm mt-5 w-full flex items-start'>
                           <span className='font-bold text-nowrap'>Fixed Fee:</span>

--- a/src/app/(user)/(pages)/fee/page.tsx
+++ b/src/app/(user)/(pages)/fee/page.tsx
@@ -476,7 +476,7 @@ const Page = () => {
                           !showPaymentOfSemiFinal &&
                           !showPaymentOfFinal && (
                             <div className='flex flex-col justify-center items-center w-full border-[0.5px] rounded-lg px-5 py-3'>
-                              {srData?.overAllBalance <= 0 && (
+                              {(!srData?.overAllBalance || srData?.overAllBalance <= 0) && (
                                 <>
                                   <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
                                     <h1 className='flex gap-x-2 justify-center items-center'>
@@ -490,7 +490,7 @@ const Page = () => {
                                 </>
                               )}
                               <div className='flex items-center justify-center flex-col'>
-                                {srData?.overAllBalance <= 0 && (
+                                {(!srData?.overAllBalance || srData?.overAllBalance <= 0) && (
                                   <>
                                     <SettleTermPayment
                                       perTermPayment={paymentPerTermCurrent}
@@ -501,15 +501,15 @@ const Page = () => {
                                       type={'fullPayment'}
                                       title='Full Payment'
                                       isScholarshipStart={isScholarshipStart}
+                                      passbookPaymentBoolean={!srData?.passbookPayment}
                                     />
                                     <span className=''>or</span>
                                   </>
                                 )}
-
                                 <DownPayment
                                   enrollment={data?.enrollment}
                                   tfData={tfData?.tFee}
-                                  srData={srData}
+                                  srData={srData?.studentReceipt || []}
                                   // amountToPay={Number(tfData?.tFee?.downPayment).toFixed(2)}
                                   type={'downPayment'}
                                   title='Down Payment'

--- a/src/app/(user)/(pages)/record/college/[id]/fee/components/SettleTermPayment.tsx
+++ b/src/app/(user)/(pages)/record/college/[id]/fee/components/SettleTermPayment.tsx
@@ -18,9 +18,10 @@ type IProps = {
   title: string;
   isScholarshipStart: Boolean;
   perTermPayment: any;
+  passbookPaymentBoolean?: boolean;
 };
 
-const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment }: IProps) => {
+const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment, passbookPaymentBoolean }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [amountPayment, setAmountPayment] = useState(0.0);
   const [insuranceFee, setInsuranceFee] = useState(false);
@@ -40,7 +41,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
       let totalAmountToPay = amountToPay;
       if (type === 'fullPayment' && !isScholarshipStart) totalAmountToPay = parseFloat((amountToPay - amountToPay * 0.1).toFixed(2));
       setAmountPayment(totalAmountToPay);
-      const a = Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0);
+      const a = Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0) + Number(passbookPaymentBoolean ? tfData?.passbookFee || 0 : 0);
       setExtraPayment(a);
       if (type.toLowerCase() === 'fullpayment') totalAmountToPay = totalAmountToPay + a;
 
@@ -49,7 +50,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
       const totalPayment = Number(totalAmountToPay) + Number(fee) + 15;
       totalPaymentRef.current = parseFloat(totalPayment.toFixed(2));
     }
-  }, [srData, tfData, enrollment, amountToPay, type, isScholarshipStart]);
+  }, [srData, tfData, enrollment, amountToPay, type, isScholarshipStart, passbookPaymentBoolean]);
 
   const formattedAmount = (amount: number) => {
     return amount ? amount.toFixed(2) : '0.00';
@@ -207,7 +208,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-nowrap'>Departmental Fee:</span>
                             </div>
                             <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.departmentalFee}</span>
+                              <span className='font-bold text-end w-full'>₱{tfData?.departmentalFee}</span>
                             </div>
                           </div>
                           {insuranceFee && (
@@ -217,7 +218,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               </div>
 
                               <div className='text-sm mt-5 w-ful flex items-end'>
-                                <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
+                                <span className='font-bold text-end w-full'>₱{tfData?.insuranceFee}</span>
                               </div>
                             </div>
                           )}
@@ -226,9 +227,20 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-nowrap'>SSG Fee:</span>
                             </div>
                             <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.ssgFee}</span>
+                              <span className='font-bold text-end w-full'>₱{tfData?.ssgFee}</span>
                             </div>
                           </div>
+                          {passbookPaymentBoolean && (
+                            <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
+                              <div className='text-sm mt-5 w-full flex items-start'>
+                                <span className='font-bold text-nowrap'>Passbook Fee:</span>
+                              </div>
+
+                              <div className='text-sm mt-5 w-ful flex items-end'>
+                                <span className='font-bold text-end w-full'>₱{tfData?.passbookFee}</span>
+                              </div>
+                            </div>
+                          )}
                         </>
                       )}
                       <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>

--- a/src/app/(user)/(pages)/record/college/[id]/fee/page.tsx
+++ b/src/app/(user)/(pages)/record/college/[id]/fee/page.tsx
@@ -471,7 +471,7 @@ const Page = ({ params }: { params: { id: string } }) => {
                           !showPaymentOfSemiFinal &&
                           !showPaymentOfFinal && (
                             <div className='flex flex-col justify-center items-center w-full border-[0.5px] rounded-lg px-5 py-3'>
-                              {srData?.overAllBalance <= 0 && (
+                              {(!srData?.overAllBalance || srData?.overAllBalance <= 0) && (
                                 <>
                                   <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
                                     <h1 className='flex gap-x-2 justify-center items-center'>
@@ -486,7 +486,7 @@ const Page = ({ params }: { params: { id: string } }) => {
                               )}
 
                               <div className='flex items-center justify-center flex-col'>
-                                {srData?.overAllBalance <= 0 && (
+                                {(!srData?.overAllBalance || srData?.overAllBalance <= 0) && (
                                   <>
                                     <SettleTermPayment
                                       perTermPayment={paymentPerTermCurrent}
@@ -497,6 +497,7 @@ const Page = ({ params }: { params: { id: string } }) => {
                                       type={'fullPayment'}
                                       title='Full Payment'
                                       isScholarshipStart={isScholarshipStart}
+                                      passbookPaymentBoolean={!srData?.passbookPayment}
                                     />
                                     <span className=''>or</span>
                                   </>
@@ -504,7 +505,7 @@ const Page = ({ params }: { params: { id: string } }) => {
                                 <DownPayment
                                   enrollment={data?.enrollmentRecord}
                                   tfData={tfData?.tFee}
-                                  srData={srData?.studentReceipt}
+                                  srData={srData?.studentReceipt || []}
                                   // amountToPay={Number(tfData?.tFee?.downPayment).toFixed(2)}
                                   type={'downPayment'}
                                   title='Down Payment'

--- a/src/app/accounting/(pages)/college/balance/[id]/components/SettleTermPayment.tsx
+++ b/src/app/accounting/(pages)/college/balance/[id]/components/SettleTermPayment.tsx
@@ -20,9 +20,10 @@ type IProps = {
   title: string;
   isScholarshipStart: boolean;
   perTermPayment: any;
+  passbookPaymentBoolean?: boolean;
 };
 
-const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment }: IProps) => {
+const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment, passbookPaymentBoolean }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [total, setTotal] = useState(0.0);
   const [insuranceFee, setInsuranceFee] = useState(false);
@@ -52,7 +53,8 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
       let totalAmountToPay = amountToPay;
       if (!isScholarshipStart && type === 'fullPayment') totalAmountToPay = parseFloat((amountToPay - amountToPay * 0.1).toFixed(2));
       setAmountPayment(totalAmountToPay);
-      if (type.toLowerCase() === 'fullpayment') totalAmountToPay = totalAmountToPay + Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0);
+      if (type.toLowerCase() === 'fullpayment')
+        totalAmountToPay = totalAmountToPay + Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0) + Number(passbookPaymentBoolean ? tfData?.passbookFee || 0 : 0);
       setAmountInput(totalAmountToPay);
       setTotal(totalAmountToPay);
       if (enrollment?.profileId?.scholarshipId?.amount) {
@@ -63,7 +65,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
         }
       }
     }
-  }, [srData, tfData, enrollment, amountToPay, type, isScholarshipStart, balanceGrant]);
+  }, [srData, tfData, enrollment, amountToPay, type, isScholarshipStart, balanceGrant, passbookPaymentBoolean]);
 
   const mutation = useCreateStudentReceiptMutation();
   const onSubmit = async (e: any) => {
@@ -177,7 +179,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-nowrap'>Departmental Fee:</span>
                             </div>
                             <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.departmentalFee}</span>
+                              <span className='font-bold text-end w-full'>₱{tfData?.departmentalFee}</span>
                             </div>
                           </div>
                           {insuranceFee && (
@@ -187,7 +189,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               </div>
 
                               <div className='text-sm mt-5 w-ful flex items-end'>
-                                <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
+                                <span className='font-bold text-end w-full'>₱{tfData?.insuranceFee}</span>
                               </div>
                             </div>
                           )}
@@ -196,9 +198,20 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-nowrap'>SSG Fee:</span>
                             </div>
                             <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.ssgFee}</span>
+                              <span className='font-bold text-end w-full'>₱{tfData?.ssgFee}</span>
                             </div>
                           </div>
+                          {passbookPaymentBoolean && (
+                            <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
+                              <div className='text-sm mt-5 w-full flex items-start'>
+                                <span className='font-bold text-nowrap'>Passbook Fee:</span>
+                              </div>
+
+                              <div className='text-sm mt-5 w-ful flex items-end'>
+                                <span className='font-bold text-end w-full'>₱{tfData?.passbookFee}</span>
+                              </div>
+                            </div>
+                          )}
                           <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
                             <div className='text-sm mt-5 w-full flex items-start'>
                               <span className='font-bold text-nowrap'>Total Payment Amount:</span>

--- a/src/app/accounting/(pages)/college/balance/[id]/page.tsx
+++ b/src/app/accounting/(pages)/college/balance/[id]/page.tsx
@@ -283,7 +283,7 @@ const Page = ({ params }: { params: { id: string } }) => {
     .replace(/(\S),/g, '$1,')
     .replace(/,(\S)/g, ', $1')
     .trim();
-
+  console.log('srData', srData);
   return (
     <>
       {isPageLoading ? (
@@ -484,7 +484,7 @@ const Page = ({ params }: { params: { id: string } }) => {
                                   </>
                                 )}
                                 <div className='flex flex-col items-center justify-center'>
-                                  {srData?.overAllBalance < 0 && (
+                                  {(!srData?.overAllBalance || srData?.overAllBalance <= 0) && (
                                     <>
                                       <SettleTermPayment
                                         perTermPayment={paymentPerTermCurrent}
@@ -495,12 +495,21 @@ const Page = ({ params }: { params: { id: string } }) => {
                                         type={'fullPayment'}
                                         title='Full Payment'
                                         isScholarshipStart={isScholarshipStart}
+                                        passbookPaymentBoolean={!srData?.passbookPayment}
                                       />
                                       <span className='text-sm uppercase font-semibold'>OR</span>
                                     </>
                                   )}
 
-                                  <DownPayment enrollment={data?.enrollment} tfData={tfData?.tFee} srData={srData} amountToPay={Number(tfData?.tFee?.downPayment).toFixed(2)} type={'downPayment'} title='Down Payment' isScholarshipStart={isScholarshipStart} />
+                                  <DownPayment
+                                    enrollment={data?.enrollment}
+                                    tfData={tfData?.tFee}
+                                    srData={srData?.studentReceipt || []}
+                                    amountToPay={Number(tfData?.tFee?.downPayment).toFixed(2)}
+                                    type={'downPayment'}
+                                    title='Down Payment'
+                                    isScholarshipStart={isScholarshipStart}
+                                  />
                                 </div>
                               </div>
                             ) : Number(data?.enrollment?.profileId?.scholarshipId.amount) >= Number(total) ? (
@@ -528,11 +537,20 @@ const Page = ({ params }: { params: { id: string } }) => {
                                         type={'fullPayment'}
                                         title='Full Payment'
                                         isScholarshipStart={isScholarshipStart}
+                                        passbookPaymentBoolean={!srData?.passbookPayment}
                                       />
                                       <span className='text-sm uppercase font-semibold'>OR</span>
                                     </>
                                   )}
-                                  <DownPayment enrollment={data?.enrollment} tfData={tfData?.tFee} srData={srData} amountToPay={Number(tfData?.tFee?.downPayment).toFixed(2)} type={'downPayment'} title='Down Payment' isScholarshipStart={isScholarshipStart} />
+                                  <DownPayment
+                                    enrollment={data?.enrollment}
+                                    tfData={tfData?.tFee}
+                                    srData={srData?.studentReceipt || []}
+                                    amountToPay={Number(tfData?.tFee?.downPayment).toFixed(2)}
+                                    type={'downPayment'}
+                                    title='Down Payment'
+                                    isScholarshipStart={isScholarshipStart}
+                                  />
                                 </div>
                               </div>
                             ) : null}

--- a/src/app/accounting/(pages)/college/record/[id]/fee/components/SettleTermPayment.tsx
+++ b/src/app/accounting/(pages)/college/record/[id]/fee/components/SettleTermPayment.tsx
@@ -20,9 +20,10 @@ type IProps = {
   title: string;
   isScholarshipStart: boolean;
   perTermPayment: any;
+  passbookPaymentBoolean?: boolean;
 };
 
-const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment }: IProps) => {
+const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, title, isScholarshipStart, perTermPayment, passbookPaymentBoolean }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [total, setTotal] = useState(0.0);
   const [insuranceFee, setInsuranceFee] = useState(false);
@@ -52,7 +53,8 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
       let totalAmountToPay = amountToPay;
       if (!isScholarshipStart && type === 'fullPayment') totalAmountToPay = parseFloat((amountToPay - amountToPay * 0.1).toFixed(2));
       setAmountPayment(totalAmountToPay);
-      if (type.toLowerCase() === 'fullpayment') totalAmountToPay = totalAmountToPay + Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0);
+      if (type.toLowerCase() === 'fullpayment')
+        totalAmountToPay = totalAmountToPay + Number(tfData?.departmentalFee || 0) + Number(tfData?.ssgFee || 0) + Number(insurence ? tfData?.insuranceFee || 0 : 0) + Number(passbookPaymentBoolean ? tfData?.passbookFee || 0 : 0);
       setAmountInput(totalAmountToPay);
       setTotal(totalAmountToPay);
       if (enrollment?.profileId?.scholarshipId?.amount) {
@@ -63,7 +65,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
         }
       }
     }
-  }, [srData, tfData, enrollment, amountToPay, type, isScholarshipStart, balanceGrant]);
+  }, [srData, tfData, enrollment, amountToPay, type, isScholarshipStart, balanceGrant, passbookPaymentBoolean]);
 
   const mutation = useCreateStudentReceiptMutation();
   const onSubmit = async (e: any) => {
@@ -182,7 +184,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-nowrap'>Departmental Fee:</span>
                             </div>
                             <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.departmentalFee}</span>
+                              <span className='font-bold text-end w-full'>₱{tfData?.departmentalFee}</span>
                             </div>
                           </div>
                           {insuranceFee && (
@@ -192,7 +194,7 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               </div>
 
                               <div className='text-sm mt-5 w-ful flex items-end'>
-                                <span className='font-bold text-end w-full'>₱{tfData.insuranceFee}</span>
+                                <span className='font-bold text-end w-full'>₱{tfData?.insuranceFee}</span>
                               </div>
                             </div>
                           )}
@@ -201,9 +203,20 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
                               <span className='font-bold text-nowrap'>SSG Fee:</span>
                             </div>
                             <div className='text-sm mt-5 w-ful flex items-end'>
-                              <span className='font-bold text-end w-full'>₱{tfData.ssgFee}</span>
+                              <span className='font-bold text-end w-full'>₱{tfData?.ssgFee}</span>
                             </div>
                           </div>
+                          {passbookPaymentBoolean && (
+                            <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
+                              <div className='text-sm mt-5 w-full flex items-start'>
+                                <span className='font-bold text-nowrap'>Passbook Fee:</span>
+                              </div>
+
+                              <div className='text-sm mt-5 w-ful flex items-end'>
+                                <span className='font-bold text-end w-full'>₱{tfData?.passbookFee}</span>
+                              </div>
+                            </div>
+                          )}
                           <div className='flex flex-row w-full sm:gap-28 xs:gap-10'>
                             <div className='text-sm mt-5 w-full flex items-start'>
                               <span className='font-bold text-nowrap'>Total Payment Amount:</span>

--- a/src/app/accounting/(pages)/college/record/[id]/fee/page.tsx
+++ b/src/app/accounting/(pages)/college/record/[id]/fee/page.tsx
@@ -479,7 +479,7 @@ const Page = ({ params }: { params: { id: string } }) => {
                           <>
                             {data?.enrollmentRecord?.profileId?.scholarshipId?.type.toLowerCase() !== 'fixed' ? (
                               <div className='flex flex-col justify-center items-center w-full border-[0.5px] rounded-lg px-5 py-3'>
-                                {srData?.overAllBalance <= 0 && (
+                                {(!srData?.overAllBalance || srData?.overAllBalance <= 0) && (
                                   <>
                                     <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
                                       <h1 className='flex gap-x-2 justify-center items-center'>
@@ -490,7 +490,7 @@ const Page = ({ params }: { params: { id: string } }) => {
                                   </>
                                 )}
                                 <div className='flex flex-col items-center justify-center'>
-                                  {srData?.overAllBalance <= 0 && (
+                                  {(!srData?.overAllBalance || srData?.overAllBalance <= 0) && (
                                     <>
                                       <SettleTermPayment
                                         perTermPayment={paymentPerTermCurrent}
@@ -501,6 +501,7 @@ const Page = ({ params }: { params: { id: string } }) => {
                                         type={'fullPayment'}
                                         title='Full Payment'
                                         isScholarshipStart={isScholarshipStart}
+                                        passbookPaymentBoolean={!srData?.passbookPayment}
                                       />
                                       <span className='text-sm uppercase font-semibold'>OR</span>
                                     </>
@@ -518,19 +519,17 @@ const Page = ({ params }: { params: { id: string } }) => {
                               </div>
                             ) : Number(data?.enrollmentRecord?.profileId?.scholarshipId.amount) >= Number(total) ? (
                               <div className='flex flex-col justify-center items-center w-full border-[0.5px] rounded-lg px-5 py-3'>
-                                {srData?.overAllBalance <= 0 && (
-                                  <>
-                                    <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
-                                      <h1 className='flex gap-x-2 justify-center items-center'>
-                                        <span className='text-[16px] font-bold text-orange-400'>Note:</span>
-                                        <span className='text-sm text-justify'>Full payment for the semester is only applicable for the initial payment and includes a 10% discount.</span>
-                                      </h1>
-                                    </div>
-                                  </>
+                                {(!srData?.overAllBalance || srData?.overAllBalance <= 0) && (
+                                  <div className='px-5 w-full sm:px-1 flex justify-center flex-col mt-5'>
+                                    <h1 className='flex gap-x-2 justify-center items-center'>
+                                      <span className='text-[16px] font-bold text-orange-400'>Note:</span>
+                                      <span className='text-sm text-justify'>Full payment for the semester is only applicable for the initial payment and includes a 10% discount.</span>
+                                    </h1>
+                                  </div>
                                 )}
 
                                 <div className='flex flex-col items-center justify-center'>
-                                  {srData?.overAllBalance <= 0 && (
+                                  {(!srData?.overAllBalance || srData?.overAllBalance <= 0) && (
                                     <>
                                       <SettleTermPayment
                                         perTermPayment={paymentPerTermCurrent}
@@ -541,11 +540,20 @@ const Page = ({ params }: { params: { id: string } }) => {
                                         type={'fullPayment'}
                                         title='Full Payment'
                                         isScholarshipStart={isScholarshipStart}
+                                        passbookPaymentBoolean={!srData?.passbookPayment}
                                       />
                                       <span className='text-sm uppercase font-semibold'>OR</span>
                                     </>
                                   )}
-                                  <DownPayment enrollment={data?.enrollment} tfData={tfData?.tFee} srData={srData} amountToPay={Number(tfData?.tFee?.downPayment).toFixed(2)} type={'downPayment'} title='Down Payment' isScholarshipStart={isScholarshipStart} />
+                                  <DownPayment
+                                    enrollment={data?.enrollment}
+                                    tfData={tfData?.tFee}
+                                    srData={srData?.studentReceipt || []}
+                                    amountToPay={Number(tfData?.tFee?.downPayment).toFixed(2)}
+                                    type={'downPayment'}
+                                    title='Down Payment'
+                                    isScholarshipStart={isScholarshipStart}
+                                  />
                                 </div>
                               </div>
                             ) : null}


### PR DESCRIPTION
# Pull Request Template

## Description
Added passbook fee handling in full payments and fixed full payment display issues:

- Added the passbook fee inclusion in full payment processing.
- Fixed the display logic for full payment, ensuring it only appears if the student has no remaining balance from previous enrollments.

---

## Related Issue
<!-- If this pull request fixes an issue, add "Fixes #<issue_number>" to automatically close the issue when merged. -->
N/A

---

## Changes Made
- Included the passbook fee in full payment calculations.
- Adjusted the logic to properly display the full payment option when a student has no outstanding balance from past enrollments.

---

## How to Test
1. Attempt a full payment and confirm that the passbook fee is included in the total.
2. Check if the full payment option is hidden when the student still has a balance from previous enrollments.
3. Verify that the UI correctly reflects the changes after a payment is made.

---

## Screenshots or Logs (if applicable)
<!-- Attach screenshots or logs to highlight the changes made, especially for UI/UX-related PRs or major changes. -->

---

## Checklist
<!-- Mark items as completed using an "x" -->
- [x] I have tested my changes thoroughly.  
- [x] I have followed the project's code style guidelines.  
- [x] I have added/updated necessary documentation.  
- [x] I have linked relevant issues to this PR.  
- [x] I have ensured there are no new warnings or errors in the code.

---

## Notes for Reviewers
