### PR TITLE
fixing displayment of current semester fees if it just has a previous balance

### DIFF
--- a/src/app/(user)/(pages)/fee/page.tsx
+++ b/src/app/(user)/(pages)/fee/page.tsx
@@ -749,26 +749,28 @@ const Page = () => {
                           {!data?.enrollment?.profileId?.scholarshipId?.amount && !isScholarshipStart && Number(total) > Number(totalCurrent) && (
                             <>
                               {srData && srData?.previousBalance.length > 0 && (
-                                <div className='grid grid-cols-1 sm:px-36 px-5'>
-                                  {srData.previousBalance.map((balance: any, index: number) => (
-                                    <div key={index} className='flex justify-between'>
-                                      <span className='font-medium'>
-                                        Outstanding Balance
-                                        <span className='text-xs text-muted-foreground'>
-                                          ({balance?.year}- {balance?.semester})
+                                <>
+                                  <div className='grid grid-cols-1 sm:px-36 px-5'>
+                                    {srData.previousBalance.map((balance: any, index: number) => (
+                                      <div key={index} className='flex justify-between'>
+                                        <span className='font-medium'>
+                                          Outstanding Balance
+                                          <span className='text-xs text-muted-foreground'>
+                                            ({balance?.year}- {balance?.semester})
+                                          </span>
                                         </span>
-                                      </span>
-                                      <span>₱{Number(balance?.balanceToShow).toFixed(2)}</span>
+                                        <span>₱{Number(balance?.balanceToShow).toFixed(2)}</span>
+                                      </div>
+                                    ))}
+                                  </div>
+                                  <div className='grid grid-cols-1 sm:px-36 px-5'>
+                                    <div className='flex justify-between'>
+                                      <span className='font-medium'>Current Semester Fees</span>
+                                      <span>₱{Number(totalCurrent).toFixed(2) || (0).toFixed(2)}</span>
                                     </div>
-                                  ))}
-                                </div>
+                                  </div>
+                                </>
                               )}
-                              <div className='grid grid-cols-1 sm:px-36 px-5'>
-                                <div className='flex justify-between'>
-                                  <span className='font-medium'>Current Semester Fees</span>
-                                  <span>₱{Number(totalCurrent).toFixed(2) || (0).toFixed(2)}</span>
-                                </div>
-                              </div>
                             </>
                           )}
                           <div className='grid grid-cols-1 sm:px-36 px-5'>

--- a/src/app/(user)/(pages)/record/college/[id]/fee/page.tsx
+++ b/src/app/(user)/(pages)/record/college/[id]/fee/page.tsx
@@ -822,26 +822,28 @@ const Page = ({ params }: { params: { id: string } }) => {
                           {Number(total) > Number(totalCurrent) && (
                             <>
                               {srData && srData?.previousBalance.length > 0 && (
-                                <div className='grid grid-cols-1 sm:px-36 px-5'>
-                                  {srData.previousBalance.map((balance: any, index: number) => (
-                                    <div key={index} className='flex justify-between'>
-                                      <span className='font-medium'>
-                                        Outstanding Balance
-                                        <span className='text-xs text-muted-foreground'>
-                                          ({balance?.year}- {balance?.semester})
+                                <>
+                                  <div className='grid grid-cols-1 sm:px-36 px-5'>
+                                    {srData.previousBalance.map((balance: any, index: number) => (
+                                      <div key={index} className='flex justify-between'>
+                                        <span className='font-medium'>
+                                          Outstanding Balance
+                                          <span className='text-xs text-muted-foreground'>
+                                            ({balance?.year}- {balance?.semester})
+                                          </span>
                                         </span>
-                                      </span>
-                                      <span>₱{Number(balance?.balanceToShow).toFixed(2)}</span>
+                                        <span>₱{Number(balance?.balanceToShow).toFixed(2)}</span>
+                                      </div>
+                                    ))}
+                                  </div>
+                                  <div className='grid grid-cols-1 sm:px-36 px-5'>
+                                    <div className='flex justify-between'>
+                                      <span className='font-medium'>Current Semester Fees</span>
+                                      <span>₱{Number(totalCurrent).toFixed(2) || (0).toFixed(2)}</span>
                                     </div>
-                                  ))}
-                                </div>
+                                  </div>
+                                </>
                               )}
-                              <div className='grid grid-cols-1 sm:px-36 px-5'>
-                                <div className='flex justify-between'>
-                                  <span className='font-medium'>Current Semester Fees</span>
-                                  <span>₱{Number(totalCurrent).toFixed(2) || (0).toFixed(2)}</span>
-                                </div>
-                              </div>
                             </>
                           )}
                           <div className='grid grid-cols-1 sm:px-36 px-5'>

--- a/src/app/accounting/(pages)/college/balance/[id]/page.tsx
+++ b/src/app/accounting/(pages)/college/balance/[id]/page.tsx
@@ -206,24 +206,24 @@ const Page = ({ params }: { params: { id: string } }) => {
         const a = cFormatted;
         let RegMiscTotal = a;
         const totalOfNew = ccFormatted;
-        console.log('a1', RegMiscTotal)
+        console.log('a1', RegMiscTotal);
         if (tfData?.tFee?.regOrMiscWithOldAndNew) {
           if (data?.enrollment?.studentStatus.toLowerCase() === 'new student' || data?.enrollment?.studentStatus.toLowerCase() === 'transfer student') {
             setRegMiscTotal(totalOfNew);
             RegMiscTotal = totalOfNew;
-            console.log('2', RegMiscTotal)
+            console.log('2', RegMiscTotal);
           } else {
             RegMiscTotal = a;
             setRegMiscTotal(a);
-            console.log('3', RegMiscTotal)
+            console.log('3', RegMiscTotal);
           }
         } else {
           RegMiscTotal = a;
           setRegMiscTotal(a);
-          console.log('4', RegMiscTotal)
+          console.log('4', RegMiscTotal);
         }
-        
-        console.log('5', RegMiscTotal)
+
+        console.log('5', RegMiscTotal);
         if (isScholarshipStart && data?.enrollment?.profileId?.scholarshipId?.exemptedFees.includes('Miscellaneous Fees')) {
           if (data?.enrollment?.profileId?.scholarshipId?.type === 'percentage') {
             const b = parseFloat((a * Number(data?.enrollment?.profileId?.scholarshipId?.discountPercentage)).toFixed(2));
@@ -790,26 +790,29 @@ const Page = ({ params }: { params: { id: string } }) => {
                           {!data?.enrollment?.profileId?.scholarshipId?.amount && !isScholarshipStart && Number(total) > Number(totalCurrent) && (
                             <>
                               {srData && srData?.previousBalance?.length > 0 && (
-                                <div className='grid grid-cols-1 sm:px-36 px-5'>
-                                  {srData.previousBalance.map((balance: any, index: number) => (
-                                    <div key={index} className='flex justify-between'>
-                                      <span className='font-medium'>
-                                        Outstanding Balance
-                                        <span className='text-xs text-muted-foreground'>
-                                          ({balance?.year}- {balance?.semester})
+                                <>
+                                  <div className='grid grid-cols-1 sm:px-36 px-5'>
+                                    {srData.previousBalance.map((balance: any, index: number) => (
+                                      <div key={index} className='flex justify-between'>
+                                        <span className='font-medium'>
+                                          Outstanding Balance
+                                          <span className='text-xs text-muted-foreground'>
+                                            ({balance?.year}- {balance?.semester})
+                                          </span>
                                         </span>
-                                      </span>
-                                      <span>₱{Number(balance?.balanceToShow).toFixed(2)}</span>
+                                        <span>₱{Number(balance?.balanceToShow).toFixed(2)}</span>
+                                      </div>
+                                    ))}
+                                  </div>
+
+                                  <div className='grid grid-cols-1 sm:px-36 px-5'>
+                                    <div className='flex justify-between'>
+                                      <span className='font-medium'>Current Semester Fees</span>
+                                      <span>₱{Number(totalCurrent).toFixed(2) || (0).toFixed(2)}</span>
                                     </div>
-                                  ))}
-                                </div>
+                                  </div>
+                                </>
                               )}
-                              <div className='grid grid-cols-1 sm:px-36 px-5'>
-                                <div className='flex justify-between'>
-                                  <span className='font-medium'>Current Semester Fees</span>
-                                  <span>₱{Number(totalCurrent).toFixed(2) || (0).toFixed(2)}</span>
-                                </div>
-                              </div>
                             </>
                           )}
                           <div className='grid grid-cols-1 sm:px-36 px-5'>

--- a/src/app/accounting/(pages)/college/balance/components/ActionsCell.tsx
+++ b/src/app/accounting/(pages)/college/balance/components/ActionsCell.tsx
@@ -34,7 +34,7 @@ const ActionsCell = ({ user }: IProps) => {
                     View student profile
                   </div>
                 </Link> */}
-                <Link href={`/accounting/college/balance/${user._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
+                <Link href={`/accounting/college/balance/${user?._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
                   <div className='flex justify-center items-center text-sm font-medium gap-x-1'>
                     <Icons.eye className='h-4 w-4' />
                     View student balance

--- a/src/app/accounting/(pages)/college/components/GoodMoralFile.tsx
+++ b/src/app/accounting/(pages)/college/components/GoodMoralFile.tsx
@@ -15,7 +15,7 @@ const GoodMoralFile = ({ user }: { user: any }) => {
   useEffect(() => {
     const fetchFileUrl = async () => {
       if (navigator.onLine && user && user.profileId.goodMoralUrl) {
-        const filePath = `enrollment/goodMoral/${user?.profileId._id}/${user?.profileId.goodMoralUrl}`;
+        const filePath = `enrollment/goodMoral/${user?.profileId?._id}/${user?.profileId?.goodMoralUrl}`;
         // if(!fireAuth.currentUser) await signInWithEmailAndPassword(fireAuth, 'admin@gmail.com', 'qweqwe')
         const fileRef = ref(storage, filePath);
 

--- a/src/app/accounting/(pages)/college/components/PSAFile.tsx
+++ b/src/app/accounting/(pages)/college/components/PSAFile.tsx
@@ -15,7 +15,7 @@ const PSAFile = ({ user }: { user: any }) => {
   useEffect(() => {
     const fetchFileUrl = async () => {
       if (navigator.onLine && user && user.profileId.psaUrl) {
-        const filePath = `enrollment/psa/${user.profileId._id}/${user.profileId.psaUrl}`;
+        const filePath = `enrollment/psa/${user?.profileId?._id}/${user.profileId.psaUrl}`;
         // if(!fireAuth.currentUser) await signInWithEmailAndPassword(fireAuth, 'admin@gmail.com', 'qweqwe')
         const fileRef = ref(storage, filePath);
 

--- a/src/app/accounting/(pages)/college/components/ReportCardFile.tsx
+++ b/src/app/accounting/(pages)/college/components/ReportCardFile.tsx
@@ -14,8 +14,8 @@ const ReportCardFile = ({ user }: { user: any }) => {
 
   useEffect(() => {
     const fetchFileUrl = async () => {
-      if (navigator.onLine && user && user.profileId.reportCardUrl) {
-        const filePath = `enrollment/reportCard/${user.profileId._id}/${user.profileId.reportCardUrl}`;
+      if (navigator.onLine && user && user?.profileId?.reportCardUrl) {
+        const filePath = `enrollment/reportCard/${user.profileId?._id}/${user.profileId?.reportCardUrl}`;
         // if(!fireAuth.currentUser) await signInWithEmailAndPassword(fireAuth, 'admin@gmail.com', 'qweqwe')
         const fileRef = ref(storage, filePath);
 

--- a/src/app/accounting/(pages)/college/components/StudentPhoto.tsx
+++ b/src/app/accounting/(pages)/college/components/StudentPhoto.tsx
@@ -13,8 +13,8 @@ const StudentPhoto = ({ user }: { user: any }) => {
 
   useEffect(() => {
     const fetchFileUrl = async () => {
-      if (navigator.onLine && user && user.profileId.photoUrl) {
-        const photoPath = `enrollment/studentphoto/${user?.profileId._id}/${user?.profileId.photoUrl}`;
+      if (navigator.onLine && user && user?.profileId?.photoUrl) {
+        const photoPath = `enrollment/studentphoto/${user?.profileId?._id}/${user?.profileId?.photoUrl}`;
         // if(!fireAuth.currentUser) await signInWithEmailAndPassword(fireAuth, 'admin@gmail.com', 'qweqwe')
 
         const fileRef = ref(storage, photoPath);

--- a/src/app/accounting/(pages)/college/discount/[id]/components/Combobox.tsx
+++ b/src/app/accounting/(pages)/college/discount/[id]/components/Combobox.tsx
@@ -70,7 +70,7 @@ export function Combobox({ form, name, label, selectItems, placeholder, fullname
                               onSelect={(currentValue) => {
                                 setValue(currentValue === value ? '' : currentValue);
                                 if (setStudentId) {
-                                  setStudentId(item._id);
+                                  setStudentId(item?._id);
                                 }
                                 field.onChange(currentValue);
                                 setOpen(false);

--- a/src/app/accounting/(pages)/college/discount/add/components/Combobox.tsx
+++ b/src/app/accounting/(pages)/college/discount/add/components/Combobox.tsx
@@ -66,7 +66,7 @@ export function Combobox({ form, name, label, selectItems, placeholder, setStude
                               onSelect={(currentValue) => {
                                 setValue(currentValue === value ? '' : currentValue);
                                 if (setStudentId) {
-                                  setStudentId(item._id);
+                                  setStudentId(item?._id);
                                 }
                                 field.onChange(currentValue);
                                 setOpen(false);

--- a/src/app/accounting/(pages)/college/discount/components/ActionsCell.tsx
+++ b/src/app/accounting/(pages)/college/discount/components/ActionsCell.tsx
@@ -29,7 +29,7 @@ const ActionsCell = ({ user }: IProps) => {
           <Command>
             <CommandList>
               <CommandGroup className=''>
-                <Link href={`/accounting/college/discount/${user._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
+                <Link href={`/accounting/college/discount/${user?._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
                   <div className='flex justify-center items-center text-sm font-medium gap-x-1'>
                     <Icons.eye className='h-4 w-4' />
                     View Scholarship

--- a/src/app/accounting/(pages)/college/enrolling/components/ActionsCell.tsx
+++ b/src/app/accounting/(pages)/college/enrolling/components/ActionsCell.tsx
@@ -28,7 +28,7 @@ const ActionsCell = ({ user }: IProps) => {
           <Command>
             <CommandList>
               <CommandGroup className=''>
-                <Link href={`/accounting/users/students/${user.userId._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
+                <Link href={`/accounting/users/students/${user?.userId?._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
                   <div className='flex justify-center items-center text-sm font-medium gap-x-1'>
                     <Icons.eye className='h-4 w-4' />
                     View balance fee

--- a/src/app/accounting/(pages)/college/receipts/components/ActionsCell.tsx
+++ b/src/app/accounting/(pages)/college/receipts/components/ActionsCell.tsx
@@ -27,7 +27,7 @@ const ActionsCell = ({ user }: IProps) => {
           <Command>
             <CommandList>
               <CommandGroup className=''>
-                <Link href={`/accounting/college/receipts/${user._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
+                <Link href={`/accounting/college/receipts/${user?._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
                   <div className='flex justify-center items-center text-sm font-medium gap-x-1'>
                     <Icons.eye className='h-4 w-4' />
                     View Receipt

--- a/src/app/accounting/(pages)/college/record/[id]/components/ActionsCell.tsx
+++ b/src/app/accounting/(pages)/college/record/[id]/components/ActionsCell.tsx
@@ -31,7 +31,7 @@ const ActionsCell = ({ user }: IProps) => {
               <CommandGroup className=''>
                 <Button disabled={isPending} type='button' size={'sm'} className={'w-full group focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-0 gap-x-1 justify-start items-center hover:text-neutral-50 font-medium'}>
                   <Link
-                    href={`${isPending ? '' : `/admin/college/rooms/schedules/${user._id}`}`}
+                    href={`${isPending ? '' : `/admin/college/rooms/schedules/${user?._id}`}`}
                     className={'w-full h-full group/item rounded-md focus-visible:ring-0 flex text-black bg-transparent gap-x-1 justify-start items-center group-hover:hover:text-neutral-50'}
                   >
                     <Icons.eye className='h-4 w-4' />

--- a/src/app/accounting/(pages)/college/record/[id]/fee/page.tsx
+++ b/src/app/accounting/(pages)/college/record/[id]/fee/page.tsx
@@ -154,7 +154,7 @@ const Page = ({ params }: { params: { id: string } }) => {
       setShowBalance(0);
     }
   }, [total, srData, paymentOfFullPayment, showPaymentOfFullPayment, paymentOfDownPayment, paymentOfPrelim, paymentOfMidterm, paymentOfSemiFinal, paymentOfFinal, showBalance, data, isScholarshipStart]);
-  
+
   useEffect(() => {
     if (isTFError || !tfData) return;
     if (error || !data) return;
@@ -851,26 +851,28 @@ const Page = ({ params }: { params: { id: string } }) => {
                           {!data?.enrollment?.profileId?.scholarshipId?.amount && !isScholarshipStart && Number(total) > Number(totalCurrent) && (
                             <>
                               {srData && srData?.previousBalance?.length > 0 && (
-                                <div className='grid grid-cols-1 sm:px-36 px-5'>
-                                  {srData.previousBalance.map((balance: any, index: number) => (
-                                    <div key={index} className='flex justify-between'>
-                                      <span className='font-medium'>
-                                        Outstanding Balance
-                                        <span className='text-xs text-muted-foreground'>
-                                          ({balance?.year}- {balance?.semester})
+                                <>
+                                  <div className='grid grid-cols-1 sm:px-36 px-5'>
+                                    {srData.previousBalance.map((balance: any, index: number) => (
+                                      <div key={index} className='flex justify-between'>
+                                        <span className='font-medium'>
+                                          Outstanding Balance
+                                          <span className='text-xs text-muted-foreground'>
+                                            ({balance?.year}- {balance?.semester})
+                                          </span>
                                         </span>
-                                      </span>
-                                      <span>₱{Number(balance?.balanceToShow).toFixed(2)}</span>
+                                        <span>₱{Number(balance?.balanceToShow).toFixed(2)}</span>
+                                      </div>
+                                    ))}
+                                  </div>
+                                  <div className='grid grid-cols-1 sm:px-36 px-5'>
+                                    <div className='flex justify-between'>
+                                      <span className='font-medium'>Current Semester Fees</span>
+                                      <span>₱{Number(totalCurrent).toFixed(2) || (0).toFixed(2)}</span>
                                     </div>
-                                  ))}
-                                </div>
+                                  </div>
+                                </>
                               )}
-                              <div className='grid grid-cols-1 sm:px-36 px-5'>
-                                <div className='flex justify-between'>
-                                  <span className='font-medium'>Current Semester Fees</span>
-                                  <span>₱{Number(totalCurrent).toFixed(2) || (0).toFixed(2)}</span>
-                                </div>
-                              </div>
                             </>
                           )}
                           <div className='grid grid-cols-1 sm:px-36 px-5'>

--- a/src/app/accounting/(pages)/college/record/components/ActionsCell.tsx
+++ b/src/app/accounting/(pages)/college/record/components/ActionsCell.tsx
@@ -27,13 +27,13 @@ const ActionsCell = ({ user }: IProps) => {
           <Command>
             <CommandList>
               <CommandGroup className=''>
-                <Link href={`/accounting/college/record/${user._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
+                <Link href={`/accounting/college/record/${user?._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
                   <div className='flex justify-center items-center text-sm font-medium gap-x-1'>
                     <Icons.eye className='h-4 w-4' />
                     View Enrollment
                   </div>
                 </Link>
-                <Link href={`/accounting/college/record/${user._id}/fee`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
+                <Link href={`/accounting/college/record/${user?._id}/fee`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
                   <div className='flex justify-center items-center text-sm font-medium gap-x-1'>
                     <Icons.eye className='h-4 w-4' />
                     View Balance

--- a/src/app/accounting/(pages)/college/scholarships/[id]/components/Combobox.tsx
+++ b/src/app/accounting/(pages)/college/scholarships/[id]/components/Combobox.tsx
@@ -70,7 +70,7 @@ export function Combobox({ form, name, label, selectItems, placeholder, fullname
                               onSelect={(currentValue) => {
                                 setValue(currentValue === value ? '' : currentValue);
                                 if (setStudentId) {
-                                  setStudentId(item._id);
+                                  setStudentId(item?._id);
                                 }
                                 field.onChange(currentValue);
                                 setOpen(false);

--- a/src/app/accounting/(pages)/college/scholarships/add/components/Combobox.tsx
+++ b/src/app/accounting/(pages)/college/scholarships/add/components/Combobox.tsx
@@ -66,7 +66,7 @@ export function Combobox({ form, name, label, selectItems, placeholder, setStude
                               onSelect={(currentValue) => {
                                 setValue(currentValue === value ? '' : currentValue);
                                 if (setStudentId) {
-                                  setStudentId(item._id);
+                                  setStudentId(item?._id);
                                 }
                                 field.onChange(currentValue);
                                 setOpen(false);

--- a/src/app/accounting/(pages)/college/scholarships/components/ActionsCell.tsx
+++ b/src/app/accounting/(pages)/college/scholarships/components/ActionsCell.tsx
@@ -29,7 +29,7 @@ const ActionsCell = ({ user }: IProps) => {
           <Command>
             <CommandList>
               <CommandGroup className=''>
-                <Link href={`/accounting/college/scholarships/${user._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
+                <Link href={`/accounting/college/scholarships/${user?._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
                   <div className='flex justify-center items-center text-sm font-medium gap-x-1'>
                     <Icons.eye className='h-4 w-4' />
                     View Scholarship

--- a/src/app/accounting/(pages)/college/tuition/components/ActionsCell.tsx
+++ b/src/app/accounting/(pages)/college/tuition/components/ActionsCell.tsx
@@ -29,7 +29,7 @@ const ActionsCell = ({ user }: IProps) => {
           <Command>
             <CommandList>
               <CommandGroup className=''>
-                <Link href={`/accounting/college/tuition/${user._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
+                <Link href={`/accounting/college/tuition/${user?._id}`} className={'w-full rounded-md focus-visible:ring-0 flex mb-2 text-black bg-transparent hover:bg-blue-600 px-2 py-2 gap-x-1 justify-start  hover:text-neutral-50 '}>
                   <div className='flex justify-center items-center text-sm font-medium gap-x-1'>
                     <Icons.eye className='h-4 w-4' />
                     View Course Fee


### PR DESCRIPTION
# Pull Request Template

## Description
Fixed the display issue where current semester fees were not showing correctly if the student only had a previous balance. Now, fees for the current semester will be displayed properly even if there is an outstanding balance from a previous term.

---

## Related Issue
<!-- If this pull request fixes an issue, add "Fixes #<issue_number>" to automatically close the issue when merged. -->
Fixes #457  

---

## Changes Made
- Adjusted fee display logic to ensure current semester fees are always shown.
- Ensured previous balance does not interfere with displaying new semester fees.
- Updated calculations to separate previous balance from current semester fees correctly.

---

## How to Test
1. Enroll a student who has a balance from a previous semester.
2. Check the fee breakdown for the current semester.
3. Verify that the correct semester fees are displayed while keeping the previous balance separate.
4. Confirm that payment calculations remain accurate.

---

## Screenshots or Logs (if applicable)
<!-- Attach screenshots or logs to highlight the changes made, especially for UI/UX-related PRs or major changes. -->

---

## Checklist
- [x] I have tested my changes thoroughly.  
- [x] I have followed the project's code style guidelines.  
- [x] I have added/updated necessary documentation.  
- [x] I have linked relevant issues to this PR.  
- [x] I have ensured there are no new warnings or errors in the code.

---

## Notes for Reviewers
Please ensure that fee display logic works correctly across different scenarios, especially for students with past due balances.
