### PR TITLE
Fix continuing student enrollment checks, withdrawn and returning students

### DIFF
--- a/src/action/enrollment/create/oldStudent/College/index.ts
+++ b/src/action/enrollment/create/oldStudent/College/index.ts
@@ -1,8 +1,4 @@
 'use server';
-import { createEnrollment, getEnrollmentByUserId } from '@/services/enrollment';
-import { getStudentProfileByUserId } from '@/services/studentProfile';
-import StudentProfile from '@/models/StudentProfile';
-import { getEnrollmentRecordByProfileId } from '@/services/enrollmentRecord';
 import { tryCatch } from '@/lib/helpers/tryCatch';
 import { handleStudentRole } from './roles/student';
 

--- a/src/action/enrollment/create/oldStudent/College/roles/student.ts
+++ b/src/action/enrollment/create/oldStudent/College/roles/student.ts
@@ -4,6 +4,9 @@ import { createEnrollment, getEnrollmentByUserId } from '@/services/enrollment';
 import { getStudentProfileByUserId } from '@/services/studentProfile';
 import { getEnrollmentRecordByProfileId } from '@/services/enrollmentRecord';
 import StudentProfile from '@/models/StudentProfile';
+import { getCourseFeeByCourseCodeAndYearAndSemester } from '@/services/courseFeeRecord';
+import { getStudentReceiptByStudentId } from '@/services/studentReceipt';
+import { isScholarshipApplicable } from '@/constant/scholarship';
 
 export const handleStudentRole = async (user: any, data: any) => {
   return tryCatch(async () => {
@@ -12,11 +15,28 @@ export const handleStudentRole = async (user: any, data: any) => {
     const profile = await getStudentProfileByUserId(user._id);
     if (!profile) return { error: 'You are enrolling without a profile.', status: 403 };
 
-    if (data.studentStatus === 'Returning') {
-      const record = await getEnrollmentRecordByProfileId(profile._id);
-      if (!record) return { error: 'No record found', status: 403 };
-      if (profile.studentSemester === data.studentSemester) {
-        return { message: 'Returning student: needs to wait for the next available enrollment period', status: 403 };
+    // if (data.studentStatus.toLowerCase() === 'returning' && data.studentSemester.toLowerCase() !== 'summer') {
+    //   if (!record) return { error: 'No record found', status: 403 };
+    //   console.log('asd', dataa);
+
+    //   if (profile.studentSemester !== data.studentSemester) {
+    //     return { message: 'Returning students needs to wait for the next available enrollment period', status: 403 };
+    //   }
+    // }
+    let studentReceipt;
+    const a = await getStudentReceiptByStudentId(profile?._id);
+    studentReceipt = a;
+    if (data.studentSemester.toLowerCase() !== 'summer') {
+      const a = await checkBalance(profile._id, studentReceipt);
+
+      for (const prev of a.previousBalance) {
+        const fiftyPercent = a?.total * 0.5;
+        if (prev?.balance > fiftyPercent) {
+          console.log('Balance exceeds 50% of the total amount.');
+          return { error: `Please double check your enrollment record and it has a balance of ${a?.balance}`, status: 400 };
+        } else {
+          console.log('Balance is within 50% of the total amount.');
+        }
       }
     }
     await storeEnrollment(user, profile, data);
@@ -55,5 +75,137 @@ const updateProfile = async (profile: any, data: any) => {
     };
     const updatedProfile = await StudentProfile.findByIdAndUpdate(profile._id, dataToUpdateProfile);
     if (!updatedProfile) return { message: 'Something went wrong.', status: 500 };
+  });
+};
+
+const checkBalance = async (profileId: string, studentReceipt: any) => {
+  return tryCatch(async () => {
+    // Fetch enrollment records for this student
+    let enrollmentRecords;
+    const a = await getEnrollmentRecordByProfileId(profileId);
+    enrollmentRecords = a?.filter((s) => s.enrollStatus?.toLowerCase() !== 'withdraw');
+    if (!enrollmentRecords || enrollmentRecords.length === 0) {
+      return;
+    }
+
+    let previousBalance = [];
+    let overAllBalance = 0;
+    let overAllShowBalance = 0;
+    for (const record of enrollmentRecords) {
+      // Check only past enrollments (before current year/sem)
+      const getTotal = await getTotalOfBalance(record, studentReceipt);
+      previousBalance.push({ year: record?.studentYear, semester: record?.studentSemester, schoolYear: record?.schoolYear, id: record._id.toString(), ...getTotal });
+      overAllBalance += Number(getTotal.balance || 0);
+      overAllShowBalance += Number(getTotal.balanceToShow || 0);
+    }
+
+    return { previousBalance, overAllBalance, overAllShowBalance }; // No outstanding balance
+  });
+};
+
+const getTotalOfBalance = async (enrollment: any, studentReceipt: any) => {
+  return tryCatch(async () => {
+    const courseFee = await getCourseFeeByCourseCodeAndYearAndSemester(enrollment.studentYear, enrollment.studentSemester, enrollment.courseCode);
+
+    const lab = enrollment.studentSubjects.reduce((acc: number, subject: any) => acc + Number(subject?.subject?.lab || 0), 0);
+    const unit = enrollment.studentSubjects.reduce((acc: number, subject: any) => acc + Number(subject?.subject?.unit || 0), 0);
+
+    const tFee = courseFee || {};
+    const regMisc = tFee?.regOrMisc || [];
+    const regMiscNew = tFee?.regOrMiscNew || [];
+
+    const labTotal = parseFloat((lab * tFee.ratePerLab).toFixed(2));
+    const lecTotal = parseFloat((unit * tFee.ratePerUnit).toFixed(2));
+    const regMiscTotal = parseFloat(regMisc.reduce((acc: number, fee: any) => acc + Number(fee.amount), 0).toFixed(2));
+    const regMiscNewTotal = parseFloat(regMiscNew.reduce((acc: number, fee: any) => acc + Number(fee.amount), 0).toFixed(2));
+
+    let RegMiscTotal = 0;
+    if (tFee?.regOrMiscWithOldAndNew) {
+      if (enrollment?.studentStatus.toLowerCase() === 'new student' || enrollment?.studentStatus.toLowerCase() === 'transfer student') {
+        RegMiscTotal = regMiscNewTotal;
+      } else {
+        RegMiscTotal = regMiscTotal;
+      }
+    } else {
+      RegMiscTotal = regMiscTotal;
+    }
+
+    let totalAmount = Number(labTotal || 0) + Number(lecTotal || 0) + Number(RegMiscTotal || 0);
+
+    // Check if CWTS/NSTP fee applies
+    const hasCwtsOrNstp = enrollment.studentSubjects.some((sub: any) => ['cwts', 'nstp', 'nstp1', 'nstp2', 'cwts1', 'cwts2'].includes(sub?.subject?.subjectCode.trim().toLowerCase()));
+    if (hasCwtsOrNstp) totalAmount += Number(tFee?.cwtsOrNstpFee || 0);
+
+    // Check if OJT fee applies
+    const hasOjt = enrollment.studentSubjects.some((sub: any) => ['prac1', 'prac2'].includes(sub?.subject?.subjectCode.trim().toLowerCase()));
+    if (hasOjt) totalAmount += Number(tFee?.ojtFee || 0);
+
+    // Deduct scholarship if applicable
+    // const isPaidByScholarship = studentReceipt?.filter((r: any) => r.isPaidByScholarship)?.reduce((total: number, payment: any) => total + (Number(payment?.taxes?.amount) || 0), 0);
+
+    // const totalAfterScholarship = totalAmount - isPaidByScholarship;
+
+    // Check outstanding balance after payments
+    const checkBalanceLoop = [1, 2];
+    let remainingShowBalance = 0;
+    let remainingBalance = 0;
+    let prelimBalance = 0;
+    let midtermBalance = 0;
+    let semiFinalBalance = 0;
+    let finalBalance = 0;
+
+    for (const loop of checkBalanceLoop) {
+      const filteredReceipts =
+        loop === 1
+          ? studentReceipt?.filter((r: any) => r.year.toLowerCase() === enrollment.studentYear.toLowerCase() && r.semester.toLowerCase() === enrollment.studentSemester.toLowerCase() && !r.isPaidIn?.year && !r.isPaidIn?.semester)
+          : studentReceipt?.filter((r: any) => r.year.toLowerCase() === enrollment.studentYear.toLowerCase() && r.semester.toLowerCase() === enrollment.studentSemester.toLowerCase());
+
+      const paymentOfFullPayment = filteredReceipts.find((r: any) => r?.type?.toLowerCase() === 'fullpayment');
+      let showPaymentOfFullPayment = paymentOfFullPayment;
+      const paymentOfDownPayment = filteredReceipts.find((r: any) => r?.type?.toLowerCase() === 'downpayment');
+
+      const totalWithoutDownPayment = Number(totalAmount) - Number(paymentOfDownPayment?.taxes?.amount);
+      const totalPerTerm = Math.round(totalWithoutDownPayment * 100) / 100;
+      const paymentPerTermNotRoundOff = Math.ceil((totalPerTerm / 4) * 100) / 100;
+      const paymentPerTermRoundOff = paymentPerTermNotRoundOff % 100 >= 1 ? Math.ceil(paymentPerTermNotRoundOff / 100) * 100 : Math.floor(paymentPerTermNotRoundOff / 100) * 100;
+      const paymentPerTerm = Number(paymentPerTermRoundOff);
+
+      const paymentOfPrelim = filteredReceipts?.filter((r: any) => r.type.toLowerCase() === 'prelim')?.reduce((total: number, payment: any) => total + (Number(payment?.taxes?.amount) || 0), 0);
+      if (loop === 2) prelimBalance = Number(paymentPerTerm) - Number(paymentOfPrelim);
+
+      const paymentOfMidterm = filteredReceipts?.filter((r: any) => r.type.toLowerCase() === 'midterm')?.reduce((total: number, payment: any) => total + (Number(payment?.taxes?.amount) || 0), 0);
+      if (loop === 2) midtermBalance = Number(paymentPerTerm) - Number(paymentOfMidterm);
+
+      const paymentOfSemiFinal = filteredReceipts?.filter((r: any) => r.type.toLowerCase() === 'semi-final')?.reduce((total: number, payment: any) => total + (Number(payment?.taxes?.amount) || 0), 0);
+      if (loop === 2) semiFinalBalance = Number(paymentPerTerm) - Number(paymentOfSemiFinal);
+
+      const paymentOfFinal = filteredReceipts?.filter((r: any) => r.type.toLowerCase() === 'final')?.reduce((total: number, payment: any) => total + (Number(payment?.taxes?.amount) || 0), 0);
+      const final = parseFloat((totalAmount - Number(paymentOfDownPayment?.taxes?.amount || 0) - 3 * paymentPerTerm).toFixed(2));
+      if (loop === 2) finalBalance = Number(final) - Number(paymentOfFinal);
+
+      if (!showPaymentOfFullPayment) {
+        const totalBalance = Number(totalAmount);
+        const paidAmount = Number(paymentOfDownPayment?.taxes?.amount || 0) + Number(paymentOfPrelim || 0) + Number(paymentOfMidterm || 0) + Number(paymentOfSemiFinal || 0) + Number(paymentOfFinal || 0);
+
+        if (loop === 1) {
+          remainingShowBalance = Math.round((totalBalance - paidAmount) * 100) / 100;
+        } else {
+          remainingBalance = Math.round((totalBalance - paidAmount) * 100) / 100;
+        }
+      } else {
+        if (loop === 1) {
+          remainingShowBalance = 0;
+        } else {
+          remainingBalance = 0;
+        }
+      }
+    }
+
+    const scholarship = isScholarshipApplicable(enrollment?.studentYear || 'e2e2a', enrollment?.studentSemester || 'e2e2a', enrollment?.profileId?.scholarshipId?.amount || 'e2e2a');
+    if (scholarship) {
+      remainingBalance = 0;
+    }
+
+    return { total: totalAmount, balance: remainingBalance, balanceToShow: remainingShowBalance, prelimBalance, midtermBalance, semiFinalBalance, finalBalance };
   });
 };

--- a/src/action/enrollment/create/oldStudent/index.ts
+++ b/src/action/enrollment/create/oldStudent/index.ts
@@ -1,6 +1,5 @@
 'use server';
 import dbConnect from '@/lib/db/db';
-import { getEnrollmentResponse } from '@/types';
 import { tryCatch } from '@/lib/helpers/tryCatch';
 import { checkAuth } from '@/utils/actions/session';
 import { categoryCollege } from './College';
@@ -27,6 +26,5 @@ export const createEnrollmentForOldStudentByCategoryAction = async (data: any) =
     }
 
     return res;
-    // return { message: 'hello world success', status: 201 };
   });
 };

--- a/src/app/(user)/(pages)/enrollment/college/components/CollegeOldStudent.tsx
+++ b/src/app/(user)/(pages)/enrollment/college/components/CollegeOldStudent.tsx
@@ -13,12 +13,15 @@ import Image from 'next/image';
 import Input from './Input';
 import { EnrollmentOldStudentFormValidator } from '@/lib/validators/enrollment/create/oldStudent';
 import { useCreateEnrollmentForOldStudentByCategoryMutation } from '@/lib/queries/enrollment/create/oldStudent';
+import { studentYearData } from '@/constant/enrollment';
+import { SelectInput } from './SelectInput';
 
 type IProps = {
   profile: any;
   enrollmentSetup: any;
 };
 const CollegeOldStudent = ({ profile, enrollmentSetup }: IProps) => {
+  const [isPending, setIsPending] = useState(false);
   const { data: s } = useSession();
   const mutation = useCreateEnrollmentForOldStudentByCategoryMutation();
 
@@ -41,32 +44,38 @@ const CollegeOldStudent = ({ profile, enrollmentSetup }: IProps) => {
   });
 
   useEffect(() => {
-    form.setValue('studentStatus', profile.studentStatus);
-    form.setValue('studentSemester', enrollmentSetup.enrollmentTertiary.semester);
-    form.setValue('schoolYear', enrollmentSetup.enrollmentTertiary.schoolYear);
-    if (profile.studentSemester === '1st semester') {
-      form.setValue('studentYear', profile.studentYear);
-    } else if (profile.studentSemester === '2nd semester') {
-      switch (profile.studentYear) {
-        case '1st year':
-          form.setValue('studentYear', '2nd year');
-          break;
-        case '2nd year':
-          form.setValue('studentYear', '3rd year');
-          break;
-        case '3rd year':
-          form.setValue('studentYear', '4th year');
-          break;
-        case '4th year':
-          form.setValue('studentYear', '5th year');
-          break;
-        default:
-          break;
+    form.setValue('studentStatus', profile?.studentStatus);
+    form.setValue('studentSemester', enrollmentSetup?.enrollmentTertiary?.semester);
+    form.setValue('schoolYear', enrollmentSetup?.enrollmentTertiary?.schoolYear);
+    form.setValue('studentYear', profile?.studentYear);
+    if (enrollmentSetup?.enrollmentTertiary?.semester.toLowerCase() !== 'summer') {
+      if (profile?.studentSemester === '1st semester') {
+        console.log('2');
+        form.setValue('studentYear', profile?.studentYear);
+      } else if (profile?.studentSemester === '2nd semester' && profile?.studentStatus.toLowerCase() === 'old student') {
+        console.log('3');
+        switch (profile?.studentYear) {
+          case '1st year':
+            form.setValue('studentYear', '2nd year');
+            break;
+          case '2nd year':
+            form.setValue('studentYear', '3rd year');
+            break;
+          case '3rd year':
+            form.setValue('studentYear', '4th year');
+            break;
+          case '4th year':
+            form.setValue('studentYear', '5th year');
+            break;
+          default:
+            break;
+        }
       }
     }
   }, [profile, form, enrollmentSetup]);
 
   const onSubmit: SubmitHandler<z.infer<typeof EnrollmentOldStudentFormValidator>> = async (data) => {
+    setIsPending(true);
     data.studentYear = data.studentYear.toLowerCase();
     data.studentSemester = data.studentSemester.toLowerCase();
     data.schoolYear = data.schoolYear.toLowerCase();
@@ -78,6 +87,7 @@ const CollegeOldStudent = ({ profile, enrollmentSetup }: IProps) => {
 
     mutation.mutate(dataa, {
       onSuccess: (res) => {
+        console.log('res', res)
         switch (res.status) {
           case 200:
           case 201:
@@ -91,9 +101,9 @@ const CollegeOldStudent = ({ profile, enrollmentSetup }: IProps) => {
             return;
         }
       },
-      // onSettled: () => {
-      //   setIsPending(false);
-      // },
+      onSettled: () => {
+        setIsPending(false);
+      },
     });
   };
 
@@ -123,7 +133,8 @@ const CollegeOldStudent = ({ profile, enrollmentSetup }: IProps) => {
                   {/* <SelectInput label='Select year' form={form} name={'studentYear'} selectItems={studentYearData} placeholder='Select year' /> */}
                   {/* <SelectInput label='Select semester' form={form} name={'studentSemester'} selectItems={studentSemesterData} placeholder='Select semester' /> */}
                   <Input label={`Student Status`} type='text' form={form} name={'studentStatus'} disabled={true} />
-                  <Input label={`Select Year`} type='text' form={form} name={'studentYear'} disabled={true} />
+                  {/* <Input label={`Select Year`} type='text' form={form} name={'studentYear'} disabled={false} /> */}
+                  <SelectInput label='Select year' form={form} name={'studentYear'} selectItems={studentYearData} placeholder='Select year' />
                   <Input label={`Select semester`} type='text' form={form} name={'studentSemester'} disabled={true} />
                   <Input label={`School Year`} type='text' form={form} name={'schoolYear'} disabled={true} />
                 </div>

--- a/src/app/(user)/(pages)/enrollment/college/components/Input.tsx
+++ b/src/app/(user)/(pages)/enrollment/college/components/Input.tsx
@@ -21,7 +21,7 @@ const Input = ({ name, type, form, label, disabled, classNameInput }: IProps) =>
                 type={type}
                 disabled={disabled}
                 id={name}
-                className={`${classNameInput} ${disabled ? 'cursor-not-allowed bg-slate-200' : 'bg-slate-50'} block rounded-xl px-5 pb-2 pt-7 w-full text-sm  border border-gray-200 appearance-nonefocus:outline-none focus:ring-0 focus:border-gray-400 peer pl-4 align-text-bottom`}
+                className={`${classNameInput} ${disabled ? 'cursor-not-allowed bg-slate-200' : 'bg-slate-50'} block capitalize rounded-xl px-5 pb-2 pt-7 w-full text-sm  border border-gray-200 appearance-nonefocus:outline-none focus:ring-0 focus:border-gray-400 peer pl-4 align-text-bottom`}
                 onDragStart={(e) => e.preventDefault()}
                 placeholder=''
                 {...field}

--- a/src/app/(user)/(pages)/enrollment/college/components/MainTabs.tsx
+++ b/src/app/(user)/(pages)/enrollment/college/components/MainTabs.tsx
@@ -32,7 +32,7 @@ const MainTabs = ({ search, value, enrollment, profile, enrollmentSetup, courses
     <Tabs value={`${value}`} className='w-full gap-4 '>
       {!enrollment && !enrollmentSetup?.enrollmentTertiary.open && <Open es={enrollmentSetup?.enrollmentTertiary} />}
       {enrollmentSetup?.enrollmentTertiary.open && (!enrollment && profile.studentStatus === 'New Student' && isEnrolled) && <Step0 search={search} enrollmentSetup={enrollmentSetup} courses={courses} />}
-      {enrollmentSetup?.enrollmentTertiary.open && (!enrollment && profile.studentStatus.toLowerCase() === 'old student' && isEnrolled) && <CollegeOldStudent profile={profile} enrollmentSetup={enrollmentSetup} />}
+      {enrollmentSetup?.enrollmentTertiary.open && (!enrollment && profile.studentStatus.toLowerCase() !== 'new student' && isEnrolled) && <CollegeOldStudent profile={profile} enrollmentSetup={enrollmentSetup} />}
       {enrollment && profile.enrollStatus.toLowerCase() === 'pending' && (
         <>
           <Step1 search={search} enrollment={enrollment} />

--- a/src/services/enrollmentRecord.ts
+++ b/src/services/enrollmentRecord.ts
@@ -32,11 +32,10 @@ export const getEnrollmentRecordByProfileId = async (profileId: any) => {
 
 export const getEnrollmentRecordById = async (id: any) => {
   try {
-    const TProfile = await EnrollmentRecord.findById(id)
-      .populate({
-        path: 'profileId',
-        populate: [{ path: 'scholarshipId' }, { path: 'userId' }],
-      })
+    const TProfile = await EnrollmentRecord.findById(id).populate({
+      path: 'profileId',
+      populate: [{ path: 'scholarshipId' }, { path: 'userId' }],
+    });
     return TProfile;
   } catch (error) {
     console.log('error in service:', error);


### PR DESCRIPTION
# Pull Request Template

## Description
Fixes the logic for continuing student enrollment checks, ensuring that:  
- Students must have paid all required fees before continuing.  
- Scholarship students are ignored from this check.  
- Withdrawn enrollments are ignored, as payment is not considered when a student has withdrawn.  

---

## Related Issue
Fixes #456  

---

## Changes Made
- Updated the enrollment validation logic for continuing students.  
- Excluded scholarship students from the payment check.  
- Ignored withdrawn enrollments, as payment is not required for withdrawn students.  

---

## How to Test
1. Attempt to enroll a continuing student with unpaid balances—should be blocked from enrolling.  
2. Attempt to enroll a scholarship student—should be allowed to enroll.  
3. Withdraw a student's enrollment and check that their unpaid balance does not affect re-enrollment.  

---

## Screenshots or Logs (if applicable)
<!-- Attach screenshots or logs to highlight the changes made, especially for UI/UX-related PRs or major changes. -->

---

## Checklist
- [x] I have tested my changes thoroughly.  
- [x] I have followed the project's code style guidelines.  
- [x] I have added/updated necessary documentation.  
- [x] I have linked relevant issues to this PR.  
- [x] I have ensured there are no new warnings or errors in the code.  

---

## Notes for Reviewers
- Verify that withdrawn enrollments do not affect the student's ability to re-enroll.  
- Ensure that scholarship students are correctly exempted from payment checks.  
