### PR TITLE
added realtime broadcast in queries on mutation events

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,10 +39,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <LoadingProvider>
                 <Providers session={session}>
                   <NextAuthProvider session={session}>
-                    {/* <MessageListener> */}
-                    {children}
-                    <Toaster position='top-center' reverseOrder={false} />
-                    {/* </MessageListener> */}
+                    <MessageListener>
+                      {children}
+                      <Toaster position='top-center' reverseOrder={false} />
+                    </MessageListener>
                   </NextAuthProvider>
                 </Providers>
               </LoadingProvider>

--- a/src/lib/MessageListener.tsx
+++ b/src/lib/MessageListener.tsx
@@ -9,7 +9,6 @@ const MessageListener = ({ children }: { children: React.ReactNode }) => {
   const queryClient = useQueryClient();
   useEffect(() => {
     const globalChannelName = 'global-channel'; // Define your global channel name
-
     const channel = supabase.channel(globalChannelName, {
       config: {
         broadcast: { ack: true },
@@ -21,15 +20,13 @@ const MessageListener = ({ children }: { children: React.ReactNode }) => {
         console.log('Subscribed to global channel successfully.');
       }
     });
-    channel.on('broadcast', { event: 'message' }, (payload: any) => {
-      console.log('Received message:', payload);
-      const messages = payload?.payload?.message;
-      messages.map((item: any) => {
-        if (item?.querKey) {
-          // Invalidate queries based on the queryKey from each message
-          queryClient.invalidateQueries({ queryKey: [item.querKey] });
-        }
-      });
+    channel.on('broadcast', { event: 'invalidate-query' }, (payload: any) => {
+      const queryKeys = payload?.payload?.queryKeys;
+      if (Array.isArray(queryKeys)) {
+        queryKeys.forEach(({ key1, key2 }) => {
+          queryClient.invalidateQueries({ queryKey: key2 ? [key1, key2] : [key1] });
+        });
+      }
     });
 
     return () => {

--- a/src/lib/queries/blocks/archive/schedule/index.ts
+++ b/src/lib/queries/blocks/archive/schedule/index.ts
@@ -1,4 +1,5 @@
 import { archiveCourseBlockScheduleAction } from '@/action/blocks/archive/schedule';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 /**
@@ -9,13 +10,27 @@ export const useArchiveCourseBlockScheduleMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => archiveCourseBlockScheduleAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['BlockTypeByCategory', data.category] });
         queryClient.invalidateQueries({ queryKey: ['BlockTypeById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['BlockTypeByCourseId', data.courseId] });
         queryClient.invalidateQueries({ queryKey: ['TeacherScheduleByCategory', data.category] });
         queryClient.invalidateQueries({ queryKey: ['TeacherScheduleByProfileId', data.profileId] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'BlockTypeByCategory', key2: data.category },
+              { key1: 'BlockTypeById', key2: data.id },
+              { key1: 'BlockTypeByCourseId', key2: data.courseId },
+              { key1: 'TeacherScheduleByCategory', key2: data.category },
+              { key1: 'TeacherScheduleByProfileId', key2: data.profileId },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/blocks/create/index.ts
+++ b/src/lib/queries/blocks/create/index.ts
@@ -1,14 +1,26 @@
 import { createCollegeCourseBlockAction } from '@/action/blocks/create';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useCreateCourseBlockMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => createCollegeCourseBlockAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['BlockTypeByCategory', data.category] });
         queryClient.invalidateQueries({ queryKey: ['BlockTypeByCourseId', data.courseId] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'BlockTypeByCategory', key2: data.category },
+              { key1: 'BlockTypeByCourseId', key2: data.courseId },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/blocks/update/index.ts
+++ b/src/lib/queries/blocks/update/index.ts
@@ -1,11 +1,12 @@
 import { updateCourseBlockScheduleAction } from '@/action/blocks/update';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateCourseBlockScheduleMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => updateCourseBlockScheduleAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['BlockTypeById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['BlockTypeByCourseId', data.courseId] });
@@ -14,8 +15,30 @@ export const useUpdateCourseBlockScheduleMutation = () => {
           for (const item of data.ts) {
             queryClient.invalidateQueries({ queryKey: ['useEnrollmentQueryByTeacherScheduleId', { id: item.teacherScheduleId, category: data.category }] }); // @todo broadcast
             queryClient.invalidateQueries({ queryKey: ['TeacherScheduleById', item.teacherScheduleId] }); // @todo broadcast
+            await supabase.channel('global-channel').send({
+              type: 'broadcast',
+              event: 'invalidate-query',
+              payload: {
+                queryKeys: [
+                  { key1: 'useEnrollmentQueryByTeacherScheduleId' }, // @Bug @cant fixed
+                  { key1: 'TeacherScheduleById', key2: item.teacherScheduleId },
+                ],
+              },
+            });
           }
         }
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'BlockTypeById', key2: data.id },
+              { key1: 'BlockTypeByCourseId', key2: data.courseId },
+              { key1: 'TeacherScheduleByCategory', key2: data.category },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/courseFee/create/index.ts
+++ b/src/lib/queries/courseFee/create/index.ts
@@ -1,13 +1,22 @@
 import { createTuitionFeeAction } from '@/action/courseFee/create';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useCreatTuitionFeeMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => createTuitionFeeAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['TuitionFeeByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [{ key1: 'TuitionFeeByCategory', key2: data.category }],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/courseFee/update/index.ts
+++ b/src/lib/queries/courseFee/update/index.ts
@@ -1,14 +1,26 @@
 import { updateTuitionFeeAction } from '@/action/courseFee/update';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateTuitionFeeMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => updateTuitionFeeAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['TuitionFeeByCategory', data.category] });
         queryClient.invalidateQueries({ queryKey: ['TuitionFeeById', data.id] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'TuitionFeeByCategory', key2: data.category },
+              { key1: 'TuitionFeeById', key2: data.id },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/courses/archive/index.ts
+++ b/src/lib/queries/courses/archive/index.ts
@@ -1,4 +1,5 @@
 import { archiveCourseAction } from '@/action/courses/archive';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 /**
@@ -9,10 +10,21 @@ export const useArchiveCourseMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => archiveCourseAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['CurriculumById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['CourseByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'CurriculumById', key2: data.id },
+              { key1: 'CourseByCategory', key2: data.category },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/courses/create/index.ts
+++ b/src/lib/queries/courses/create/index.ts
@@ -1,14 +1,26 @@
 import { createCourseAction } from '@/action/courses/create';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/lib/supabaseClient';
 
 export const useCreateCourseMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => createCourseAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['CurriculumByCategory', data.category] });
         queryClient.invalidateQueries({ queryKey: ['CourseByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'CurriculumByCategory', key2: data.category },
+              { key1: 'CourseByCategory', key2: data.category },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/courses/retrieve/index.ts
+++ b/src/lib/queries/courses/retrieve/index.ts
@@ -1,4 +1,5 @@
 import { retrieveCourseAction } from '@/action/courses/retrieve';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 /**
@@ -9,10 +10,21 @@ export const useRetrieveCourseMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => retrieveCourseAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['CurriculumById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['CourseByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'CurriculumById', key2: data.id },
+              { key1: 'CourseByCategory', key2: data.category },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/courses/update/id/index.ts
+++ b/src/lib/queries/courses/update/id/index.ts
@@ -1,14 +1,26 @@
 import { updateCourseByIdAction } from '@/action/courses/update/id';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateCourseByIdMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => updateCourseByIdAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['CurriculumById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['CourseByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'CurriculumById', key2: data.id },
+              { key1: 'CourseByCategory', key2: data.category },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/curriculum/update/curriculum/index.ts
+++ b/src/lib/queries/curriculum/update/curriculum/index.ts
@@ -1,15 +1,28 @@
 import { updateCurriculumLayerAction } from '@/action/curriculum/update/curriculum';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateCurriculumLayerMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => updateCurriculumLayerAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['CurriculumById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['CurriculumByCategory', data.category] });
         queryClient.invalidateQueries({ queryKey: ['CurriculumByCourseId', data.courseId] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'CurriculumById', key2: data.id },
+              { key1: 'CurriculumByCategory', key2: data.category },
+              { key1: 'CurriculumByCourseId', key2: data.courseId },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/curriculum/update/subjectsFormat/index.ts
+++ b/src/lib/queries/curriculum/update/subjectsFormat/index.ts
@@ -1,15 +1,28 @@
 import { updateCurriculumSubjectsAction } from '@/action/curriculum/update/subjectsFormat';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateCurriculumLayerSubjectsMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => updateCurriculumSubjectsAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['CurriculumById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['CurriculumByCategory', data.category] });
         queryClient.invalidateQueries({ queryKey: ['CurriculumByCourseId', data.courseId] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'CurriculumById', key2: data.id },
+              { key1: 'CurriculumByCategory', key2: data.category },
+              { key1: 'CurriculumByCourseId', key2: data.courseId },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/endSemester/index.ts
+++ b/src/lib/queries/endSemester/index.ts
@@ -1,17 +1,25 @@
 import { EndSemesterAction } from '@/action/endSemester';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useCollegeEndSemesterMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => EndSemesterAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       // invalidate Enrollments
       queryClient.invalidateQueries({ queryKey: ['EnrollmentSetup'] });
       queryClient.invalidateQueries({ queryKey: ['EnrollmentByCategory', data.category] });
       if (data.courses && data.courses.length > 0) {
-        data.courses.forEach((e: any) => {
+        data.courses.forEach(async (e: any) => {
           queryClient.invalidateQueries({ queryKey: ['AllEnrollmentByCourseId', e._id] });
+          await supabase.channel('global-channel').send({
+            type: 'broadcast',
+            event: 'invalidate-query',
+            payload: {
+              queryKeys: [{ key1: 'BlockTypeByCourseId', key2: e._id }],
+            },
+          });
         });
       }
       queryClient.invalidateQueries({ queryKey: ['EnrollmentById'] });
@@ -20,6 +28,13 @@ export const useCollegeEndSemesterMutation = () => {
       queryClient.invalidateQueries({ queryKey: ['EnrollmentByTeacherScheduleId'] });
       for (let i = 1; i <= 6; i++) {
         queryClient.invalidateQueries({ queryKey: ['EnrollmentStepByCategory', `${data.category}-${i}`] }); // @todo broadcast
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [{ key1: 'EnrollmentStepByCategory', key2: `${data.category}-${i}` }],
+          },
+        });
       }
 
       // invalidate teacher schedule and blocks
@@ -29,8 +44,15 @@ export const useCollegeEndSemesterMutation = () => {
         queryClient.invalidateQueries({ queryKey: ['TeacherScheduleByProfileId'] });
         queryClient.invalidateQueries({ queryKey: ['BlockTypeByCategory', data.category] });
         if (data.courses && data.courses.length > 0) {
-          data.courses.forEach((e: any) => {
+          data.courses.forEach(async (e: any) => {
             queryClient.invalidateQueries({ queryKey: ['BlockTypeByCourseId', e._id] });
+            await supabase.channel('global-channel').send({
+              type: 'broadcast',
+              event: 'invalidate-query',
+              payload: {
+                queryKeys: [{ key1: 'BlockTypeByCourseId', key2: e._id }],
+              },
+            });
           });
         }
         queryClient.invalidateQueries({ queryKey: ['BlockTypeById'] });
@@ -45,6 +67,31 @@ export const useCollegeEndSemesterMutation = () => {
       queryClient.invalidateQueries({ queryKey: ['ProfileBySessionId'] });
       queryClient.invalidateQueries({ queryKey: ['ProfileByParamsUserId'] });
       queryClient.invalidateQueries({ queryKey: ['AllProfilesByRoles', 'STUDENT'] });
+
+      await supabase.channel('global-channel').send({
+        type: 'broadcast',
+        event: 'invalidate-query',
+        payload: {
+          queryKeys: [
+            { key1: 'EnrollmentSetup', key2: '' },
+            { key1: 'EnrollmentByCategory', key2: data.category },
+            { key1: 'EnrollmentById', key2: '' },
+            { key1: 'EnrollmentByProfileId', key2: '' },
+            { key1: 'EnrollmentByTeacherScheduleId', key2: '' },
+            { key1: 'TeacherScheduleByCategory', key2: data.category },
+            { key1: 'TeacherScheduleRecordById', key2: '' },
+            { key1: 'TeacherScheduleByProfileId', key2: '' },
+            { key1: 'BlockTypeByCategory', key2: data.category },
+            { key1: 'BlockTypeById', key2: '' },
+            { key1: 'ReportGradeByCategory', key2: data.category },
+            { key1: 'ReportGradeById', key2: '' },
+            { key1: 'ReportGradeByTeacherId', key2: '' },
+            { key1: 'ProfileBySessionId', key2: '' },
+            { key1: 'ProfileByParamsUserId', key2: '' },
+            { key1: 'AllProfilesByRoles', key2: 'STUDENT' },
+          ],
+        },
+      });
     },
   });
 };

--- a/src/lib/queries/enrollment/create/newStudent/index.ts
+++ b/src/lib/queries/enrollment/create/newStudent/index.ts
@@ -1,11 +1,12 @@
 import { createEnrollmentForNewStudentByCategoryAction } from '@/action/enrollment/create/newStudent';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useCreateEnrollmentForNewStudentByCategoryMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => createEnrollmentForNewStudentByCategoryAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         // @todo this query must have the id to be identified which of the authenticated student will be invalidated
         queryClient.invalidateQueries({ queryKey: ['ProfileBySessionId'] });
@@ -16,6 +17,21 @@ export const useCreateEnrollmentForNewStudentByCategoryMutation = () => {
         queryClient.invalidateQueries({ queryKey: ['EnrollmentByProfileId', data.profileId] });
         queryClient.invalidateQueries({ queryKey: ['EnrollmentBySessionId', data.userId] });
         queryClient.invalidateQueries({ queryKey: ['EnrollmentStepByCategory', `${data.category}-${data.prevStep}`] }); // @todo broadcast
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'ProfileBySessionId', key2: '' },
+              { key1: 'EnrollmentByCategory', key2: data.category },
+              { key1: 'AllEnrollmentByCourseId', key2: data.courseId },
+              { key1: 'EnrollmentByProfileId', key2: data.profileId },
+              { key1: 'EnrollmentBySessionId', key2: data.userId },
+              { key1: 'EnrollmentStepByCategory', key2: `${data.category}-${data.prevStep}` },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/enrollment/create/oldStudent/index.ts
+++ b/src/lib/queries/enrollment/create/oldStudent/index.ts
@@ -1,11 +1,12 @@
 import { createEnrollmentForOldStudentByCategoryAction } from '@/action/enrollment/create/oldStudent';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useCreateEnrollmentForOldStudentByCategoryMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => createEnrollmentForOldStudentByCategoryAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         // @todo this query must have the id to be identified which of the authenticated student will be invalidated
         queryClient.invalidateQueries({ queryKey: ['ProfileBySessionId'] });
@@ -16,6 +17,21 @@ export const useCreateEnrollmentForOldStudentByCategoryMutation = () => {
         queryClient.invalidateQueries({ queryKey: ['EnrollmentByProfileId', data.profileId] });
         queryClient.invalidateQueries({ queryKey: ['EnrollmentBySessionId', data.userId] });
         queryClient.invalidateQueries({ queryKey: ['EnrollmentStepByCategory', `${data.category}-${data.prevStep}`] }); // @todo broadcast
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'ProfileBySessionId', key2: '' },
+              { key1: 'EnrollmentByCategory', key2: data.category },
+              { key1: 'AllEnrollmentByCourseId', key2: data.courseId },
+              { key1: 'EnrollmentByProfileId', key2: data.profileId },
+              { key1: 'EnrollmentBySessionId', key2: data.userId },
+              { key1: 'EnrollmentStepByCategory', key2: `${data.category}-${data.prevStep}` },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/enrollment/remove/index.ts
+++ b/src/lib/queries/enrollment/remove/index.ts
@@ -1,4 +1,5 @@
 import { removeStudentScheduleAction } from '@/action/enrollment/remove';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 /**
@@ -9,10 +10,21 @@ export const useRemoveStudentScheduleMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => removeStudentScheduleAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['Enrollment'] });
         queryClient.invalidateQueries({ queryKey: ['EnrollmentById', data.id] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'Enrollment', key2: '' },
+              { key1: 'EnrollmentById', key2: data.id },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/enrollment/update/id/schedule/index.ts
+++ b/src/lib/queries/enrollment/update/id/schedule/index.ts
@@ -1,20 +1,37 @@
 import { updateStudentEnrollmentScheduleAction } from '@/action/enrollment/update/id/schedule';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateStudentEnrollmentScheduleMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => updateStudentEnrollmentScheduleAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
-        console.log('data', data)
         queryClient.invalidateQueries({ queryKey: ['EnrollmentById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['BlockTypeByCategory', data.category] });
-        queryClient.invalidateQueries({ queryKey: ['BlockTypeByCourseId', data.category] });
+        queryClient.invalidateQueries({ queryKey: ['BlockTypeByCourseId', data.courseId] });
         queryClient.invalidateQueries({ queryKey: ['EnrollmentByCategory', data.category] });
         queryClient.invalidateQueries({ queryKey: ['AllEnrollmentByCourseId', data.courseId] });
         queryClient.invalidateQueries({ queryKey: ['EnrollmentBySessionId', data.userId] });
         queryClient.invalidateQueries({ queryKey: ['EnrollmentStepByCategory', `${data.category}-${data.step}`] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'ProfileBySessionId', key2: '' },
+              { key1: 'BlockTypeByCategory', key2: data.category },
+              { key1: 'BlockTypeByCourseId', key2: data.courseId },
+              { key1: 'EnrollmentByCategory', key2: data.category },
+              { key1: 'AllEnrollmentByCourseId', key2: data.courseId },
+              { key1: 'EnrollmentByProfileId', key2: data.profileId },
+              { key1: 'EnrollmentBySessionId', key2: data.userId },
+              { key1: 'EnrollmentStepByCategory', key2: `${data.category}-${data.prevStep}` },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/enrollment/update/id/step/index.ts
+++ b/src/lib/queries/enrollment/update/id/step/index.ts
@@ -1,4 +1,5 @@
 import { updateEnrollmentStepAction } from '@/action/enrollment/update/id/step';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateEnrollmentStepMutation = () => {
@@ -17,6 +18,21 @@ export const useUpdateEnrollmentStepMutation = () => {
         queryClient.invalidateQueries({ queryKey: ['NotificationBySessionId'] });
         queryClient.invalidateQueries({ queryKey: ['NotificationBySessionId', data.userId, 'FRESH', 0] }); // @todo broadcast
         queryClient.invalidateQueries({ queryKey: ['NotificationBySessionId', data.userId, 'OLD', 0] }); // @todo broadcast
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'EnrollmentByCategory', key2: data.category },
+              { key1: 'AllEnrollmentByCourseId', key2: data.courseId },
+              { key1: 'EnrollmentByProfileId', key2: data.profileId },
+              { key1: 'EnrollmentBySessionId', key2: data.userId },
+              { key1: 'EnrollmentStepByCategory', key2: '' },
+              { key1: 'NotificationBySessionId', key2: `` },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/enrollment/update/id/withdraw/index.ts
+++ b/src/lib/queries/enrollment/update/id/withdraw/index.ts
@@ -1,5 +1,6 @@
 import { updateEnrollmentStepAction } from '@/action/enrollment/update/id/step';
 import { updateEnrollmentWithdrawAction } from '@/action/enrollment/update/id/withdraw';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useEnrollmentWithdrawMutation = () => {
@@ -12,10 +13,25 @@ export const useEnrollmentWithdrawMutation = () => {
         queryClient.invalidateQueries({ queryKey: ['AllEnrollmentByCourseId', data.courseId] }); // @todo broadcast
         if (data.profileId) queryClient.invalidateQueries({ queryKey: ['EnrollmentByProfileId', data.profileId] }); // @todo broadcast
         queryClient.invalidateQueries({ queryKey: ['EnrollmentBySessionId', data.id] }); // @todo broadcast
-        console.log('data')
+
         queryClient.invalidateQueries({ queryKey: ['NotificationBySessionId'] });
         queryClient.invalidateQueries({ queryKey: ['NotificationBySessionId', data.id, 'FRESH', 0] }); // @todo broadcast
         queryClient.invalidateQueries({ queryKey: ['NotificationBySessionId', data.id, 'OLD', 0] }); // @todo broadcast
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'EnrollmentByCategory', key2: data.category },
+              { key1: 'AllEnrollmentByCourseId', key2: data.courseId },
+              { key1: 'EnrollmentByProfileId', key2: data.profileId },
+              { key1: 'EnrollmentBySessionId', key2: data.id },
+              { key1: 'EnrollmentStepByCategory', key2: '' },
+              { key1: 'NotificationBySessionId', key2: `` },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/enrollmentSetup/update/index.ts
+++ b/src/lib/queries/enrollmentSetup/update/index.ts
@@ -1,12 +1,21 @@
-import { updateEnrollmentSetupAction } from "@/action/enrollmentSetup/update";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { updateEnrollmentSetupAction } from '@/action/enrollmentSetup/update';
+import { supabase } from '@/lib/supabaseClient';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateEnrollmentSetupMutation = () => {
-    const queryClient = useQueryClient();
-    return useMutation<any, Error, any>({
-      mutationFn: async (data) => updateEnrollmentSetupAction(data),
-      onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ['EnrollmentSetup'] }); // @todo broadcast
-      },
-    });
-  };
+  const queryClient = useQueryClient();
+  return useMutation<any, Error, any>({
+    mutationFn: async (data) => updateEnrollmentSetupAction(data),
+    onSuccess: async () => {
+      queryClient.invalidateQueries({ queryKey: ['EnrollmentSetup'] }); // @todo broadcast
+
+      await supabase.channel('global-channel').send({
+        type: 'broadcast',
+        event: 'invalidate-query',
+        payload: {
+          queryKeys: [{ key1: 'EnrollmentSetup', key2: '' }],
+        },
+      });
+    },
+  });
+};

--- a/src/lib/queries/notification/update/session/index.ts
+++ b/src/lib/queries/notification/update/session/index.ts
@@ -1,15 +1,24 @@
 import { updateNotificationBySessionIdAction } from '@/action/notifications/update/session';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateNotificationBySessionIdMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => updateNotificationBySessionIdAction(data),
-    onSuccess: (data, variables) => {
+    onSuccess: async (data, variables) => {
       if (data.success) {
         queryClient.invalidateQueries({ queryKey: ['NotificationBySessionId'] });
         queryClient.invalidateQueries({ queryKey: ['NotificationBySessionId', data.userId, 'FRESH', 0] }); // @todo broadcast
         queryClient.invalidateQueries({ queryKey: ['NotificationBySessionId', data.userId, 'OLD', 0] }); // @todo broadcast
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [{ key1: 'NotificationBySessionId', key2: '' }],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/reportGrade/update/id/index.ts
+++ b/src/lib/queries/reportGrade/update/id/index.ts
@@ -7,7 +7,6 @@ export const useUpdateGradeReportMutation = () => {
     mutationFn: async (data) => await updateReportGradeAction(data),
     onSuccess: async (data) => {
       if (!data.error) {
-        console.log('passed');
         queryClient.invalidateQueries({ queryKey: ['ReportGradeById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['ReportGradeByCategory', data.category] });
         queryClient.invalidateQueries({ queryKey: ['ReportGradeByTeacherId', data.teacherId] });

--- a/src/lib/queries/studentReceipt/create/index.ts
+++ b/src/lib/queries/studentReceipt/create/index.ts
@@ -1,17 +1,31 @@
 import { createStudentReceiptAction } from '@/action/studentReceipt/create';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useCreateStudentReceiptMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => createStudentReceiptAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['StudentReceiptByUserId', data.userId] });
         queryClient.invalidateQueries({ queryKey: ['StudentReceiptByUserIdAndYearAndSemester'] });
         // queryClient.invalidateQueries({ queryKey: ['StudentReceiptByUserIdAndYearAndSemester', data.userId] });
         queryClient.invalidateQueries({ queryKey: ['EnrollmentBySessionId', data.userId] });
         queryClient.invalidateQueries({ queryKey: ['StudentReceiptByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'StudentReceiptByUserId', key2: data.userId },
+              { key1: 'StudentReceiptByUserIdAndYearAndSemester', key2: '' },
+              { key1: 'EnrollmentBySessionId', key2: data.userId },
+              { key1: 'StudentReceiptByCategory', key2: data.courseId },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/subjects/archive/index.ts
+++ b/src/lib/queries/subjects/archive/index.ts
@@ -1,4 +1,5 @@
 import { archiveSubjectByIdAction } from '@/action/subjects/archive';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 /**
@@ -9,10 +10,21 @@ export const useArchiveSubjectByIdMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => archiveSubjectByIdAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['SubjectById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['SubjectByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'SubjectById', key2: data.id },
+              { key1: 'SubjectByCategory', key2: data.category },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/subjects/create/admin.ts
+++ b/src/lib/queries/subjects/create/admin.ts
@@ -1,13 +1,22 @@
 import { createNewSubjectAction } from '@/action/subjects/create/admin';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/lib/supabaseClient';
 
 export const useCreateSubjectMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => createNewSubjectAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['SubjectByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [{ key1: 'SubjectByCategory', key2: data.category }],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/subjects/retrieve/index.ts
+++ b/src/lib/queries/subjects/retrieve/index.ts
@@ -1,4 +1,5 @@
 import { retrieveSubjectByIdAction } from '@/action/subjects/retrieve';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 /**
@@ -9,10 +10,21 @@ export const useRetrieveSubjectByIdMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => retrieveSubjectByIdAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['SubjectById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['SubjectByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'SubjectById', key2: data.id },
+              { key1: 'SubjectByCategory', key2: data.category },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/subjects/update/id/index.ts
+++ b/src/lib/queries/subjects/update/id/index.ts
@@ -1,14 +1,26 @@
 import { updateSubjectByIdAction } from '@/action/subjects/update/id';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useUpdateSubjectByIdMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => updateSubjectByIdAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['SubjectById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['SubjectByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'SubjectById', key2: data.id },
+              { key1: 'SubjectByCategory', key2: data.category },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/teacherSchedule/archive/index.ts
+++ b/src/lib/queries/teacherSchedule/archive/index.ts
@@ -1,4 +1,5 @@
 import { archiveTeacherScheduleCollegeAction } from '@/action/teacherSchedule/archive';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 /**
@@ -9,11 +10,23 @@ export const useArchiveTeacherScheduleCollegeMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => archiveTeacherScheduleCollegeAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['TeacherSchedule'] });
         queryClient.invalidateQueries({ queryKey: ['TeacherScheduleByCategory', data.category] });
         queryClient.invalidateQueries({ queryKey: ['TeacherScheduleByProfileId'] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'TeacherSchedule', key2: '' },
+              { key1: 'TeacherScheduleByCategory', key2: data.category },
+              { key1: 'TeacherScheduleByProfileId', key2: '' },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/teacherSchedule/create/index.ts
+++ b/src/lib/queries/teacherSchedule/create/index.ts
@@ -1,13 +1,22 @@
 import { createTeacherScheduleAction } from '@/action/teacherSchedule/create';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useCreateTeacherScheduleByCategoryMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => createTeacherScheduleAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['TeacherScheduleByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [{ key1: 'TeacherScheduleByCategory', key2: data.category }],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/teacherSchedule/retrieve/index.ts
+++ b/src/lib/queries/teacherSchedule/retrieve/index.ts
@@ -1,4 +1,5 @@
 import { retrieveTeacherScheduleCollegeAction } from '@/action/teacherSchedule/retrieve';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 /**
@@ -9,11 +10,23 @@ export const useRetrieveTeacherScheduleCollegeMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => retrieveTeacherScheduleCollegeAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['TeacherSchedule'] });
         queryClient.invalidateQueries({ queryKey: ['TeacherScheduleByCategory', data.category] });
         queryClient.invalidateQueries({ queryKey: ['TeacherScheduleByProfileId'] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'TeacherSchedule', key2: '' },
+              { key1: 'TeacherScheduleByCategory', key2: data.category },
+              { key1: 'TeacherScheduleByProfileId', key2: '' },
+            ],
+          },
+        });
       }
     },
   });

--- a/src/lib/queries/teacherSchedule/update/index.ts
+++ b/src/lib/queries/teacherSchedule/update/index.ts
@@ -1,14 +1,26 @@
 import { editTeacherScheduleAction } from '@/action/teacherSchedule/update';
+import { supabase } from '@/lib/supabaseClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useEditTeacherScheduleByCategoryMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<any, Error, any>({
     mutationFn: async (data) => editTeacherScheduleAction(data),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (!data.error) {
         queryClient.invalidateQueries({ queryKey: ['TeacherScheduleById', data.id] });
         queryClient.invalidateQueries({ queryKey: ['TeacherScheduleByCategory', data.category] });
+
+        await supabase.channel('global-channel').send({
+          type: 'broadcast',
+          event: 'invalidate-query',
+          payload: {
+            queryKeys: [
+              { key1: 'TeacherScheduleById', key2: data.id },
+              { key1: 'TeacherScheduleByCategory', key2: data.category },
+            ],
+          },
+        });
       }
     },
   });


### PR DESCRIPTION
# Pull Request Template

## Description
Added real-time broadcast in queries when a mutation occurs.

---

## Related Issue
<!-- If this pull request fixes an issue, add "Fixes #<issue_number>" to automatically close the issue when merged. -->
Fixes #456  

---

## Changes Made
- Implemented Supabase real-time broadcasting for query invalidation.
- Modified the query invalidation logic to trigger updates when mutations occur.
- Ensured query keys now support optional second parameters.

---

## How to Test
1. Perform a mutation (e.g., create/update a course).
2. Observe if the respective queries get invalidated and re-fetched in real-time.
3. Check the console for broadcast messages.

---

## Screenshots or Logs (if applicable)
<!-- Attach screenshots or logs to highlight the changes made, especially for UI/UX-related PRs or major changes. -->

---

## Checklist
- [x] I have tested my changes thoroughly.  
- [x] I have followed the project's code style guidelines.  
- [x] I have added/updated necessary documentation.  
- [x] I have linked relevant issues to this PR.  
- [x] I have ensured there are no new warnings or errors in the code.

---

## Notes for Reviewers
- Let me know if you encounter any issues with real-time updates.
