### PR TITLE
revising the is scholarship that only trigger when the scholarship start on that enrollment

### DIFF
--- a/src/action/enrollment/create/oldStudent/College/roles/student.ts
+++ b/src/action/enrollment/create/oldStudent/College/roles/student.ts
@@ -121,7 +121,7 @@ const getTotalOfBalance = async (enrollment: any, studentReceipt: any) => {
 
     let RegMiscTotal = 0;
     if (tFee?.regOrMiscWithOldAndNew) {
-      if (enrollment?.studentStatus.toLowerCase() === 'new student' || enrollment?.studentStatus.toLowerCase() === 'transfer student') {
+      if (enrollment?.studentStatus.toLowerCase() === 'new student' || enrollment?.studentStatus.toLowerCase() === 'transfer student' || enrollment?.studentStatus.toLowerCase() === 'transferee') {
         RegMiscTotal = regMiscNewTotal;
       } else {
         RegMiscTotal = regMiscTotal;

--- a/src/action/studentReceipt/create/helpers/cash.ts
+++ b/src/action/studentReceipt/create/helpers/cash.ts
@@ -19,7 +19,7 @@ const checkPaymentInDownPaymentExceed = async (user: any, student: any, data: an
         value: data?.amount?.value,
       },
     };
-
+    console.log('isScholarship', data.isPaidByScholarship)
     const data2 = {
       year: studentEnrollment.studentYear,
       semester: studentEnrollment.studentSemester,

--- a/src/action/studentReceipt/get/yearAndSemester/index.ts
+++ b/src/action/studentReceipt/get/yearAndSemester/index.ts
@@ -99,7 +99,7 @@ const getTotalOfBalance = async (enrollment: any, studentReceipt: any) => {
 
     let RegMiscTotal = 0;
     if (tFee?.regOrMiscWithOldAndNew) {
-      if (enrollment?.studentStatus.toLowerCase() === 'new student' || enrollment?.studentStatus.toLowerCase() === 'transfer student') {
+      if (enrollment?.studentStatus.toLowerCase() === 'new student' || enrollment?.studentStatus.toLowerCase() === 'transfer student' || enrollment?.studentStatus.toLowerCase() === 'transferee') {
         RegMiscTotal = regMiscNewTotal;
       } else {
         RegMiscTotal = regMiscTotal;

--- a/src/app/accounting/(pages)/college/balance/[id]/components/SettleTermPayment.tsx
+++ b/src/app/accounting/(pages)/college/balance/[id]/components/SettleTermPayment.tsx
@@ -85,7 +85,9 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
       createTime: new Date(Date.now()),
       updateTime: new Date(Date.now()),
       isPaidByScholarship:
-        type.toLowerCase() !== 'insurance' && type.toLowerCase() !== 'departmental' && type.toLowerCase() !== 'ssg' && type.toLowerCase() !== 'passbook' && enrollment?.profileId?.scholarshipId?.amount && Number(balanceGrant) > 0 ? true : false,
+        type.toLowerCase() !== 'insurance' && type.toLowerCase() !== 'departmental' && type.toLowerCase() !== 'ssg' && type.toLowerCase() !== 'passbook' && isScholarshipStart && enrollment?.profileId?.scholarshipId?.amount && Number(balanceGrant) > 0
+          ? true
+          : false,
       taxes: {
         fee: (0).toFixed(2),
         fixed: (0).toFixed(2),

--- a/src/app/accounting/(pages)/college/record/[id]/fee/components/SettleTermPayment.tsx
+++ b/src/app/accounting/(pages)/college/record/[id]/fee/components/SettleTermPayment.tsx
@@ -87,7 +87,9 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
       createTime: new Date(Date.now()),
       updateTime: new Date(Date.now()),
       isPaidByScholarship:
-        type.toLowerCase() !== 'insurance' && type.toLowerCase() !== 'departmental' && type.toLowerCase() !== 'ssg' && type.toLowerCase() !== 'passbook' && enrollment?.profileId?.scholarshipId?.amount && Number(balanceGrant) > 0 ? true : false,
+        type.toLowerCase() !== 'insurance' && type.toLowerCase() !== 'departmental' && type.toLowerCase() !== 'ssg' && type.toLowerCase() !== 'passbook' && isScholarshipStart && enrollment?.proifleId?.scholarshipId?.amount && Number(balanceGrant) > 0
+          ? true
+          : false,
       taxes: {
         fee: (0).toFixed(2),
         fixed: (0).toFixed(2),
@@ -117,6 +119,8 @@ const SettleTermPayment = ({ enrollment, tfData, srData, amountToPay, type, titl
     });
   };
 
+  console.log('asd1', type.toLowerCase() !== 'insurance' && type.toLowerCase() !== 'departmental' && type.toLowerCase() !== 'ssg' && type.toLowerCase() !== 'passbook' && isScholarshipStart && enrollment?.profileId?.scholarshipId?.amount && Number(balanceGrant) > 0);
+  console.log('asd2', type.toLowerCase() !== 'insurance' && type.toLowerCase() !== 'departmental' && type.toLowerCase() !== 'ssg' && type.toLowerCase() !== 'passbook' && enrollment?.proifleId?.scholarshipId?.amount && Number(balanceGrant) > 0 ? true : false);
   return (
     <AlertDialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
       <AlertDialogTrigger asChild>


### PR DESCRIPTION
# Pull Request Template  

## Description  
Revised the scholarship logic to ensure that it only triggers when the scholarship starts during the enrollment period. Previously, the scholarship might have been applied incorrectly outside the intended timeframe.  

---  

## Related Issue  
Fixes #456  

---  

## Changes Made  
- Updated the scholarship logic to activate only when the scholarship is valid for the current enrollment period.  
- Ensured that scholarships granted in previous terms do not incorrectly carry over unless explicitly allowed.  
- Refactored condition checks for better accuracy in determining scholarship eligibility.  

---  

## How to Test  
1. Enroll a student with an active scholarship for the current enrollment period.  
2. Verify that the scholarship is correctly applied to the student's fees.  
3. Attempt to enroll a student with a scholarship that starts in a future term and ensure it is **not** applied.  
4. Check that payment calculations remain accurate after applying the scholarship.  

---  

## Screenshots or Logs (if applicable)  
_N/A_  

---  

## Checklist  
- [x] I have tested my changes thoroughly.  
- [x] I have followed the project's code style guidelines.  
- [x] I have added/updated necessary documentation.  
- [x] I have linked relevant issues to this PR.  
- [x] I have ensured there are no new warnings or errors in the code.  

---  

## Notes for Reviewers  
Please verify that the scholarship activation logic does not interfere with existing student financial records and correctly applies only when intended.
